### PR TITLE
Fix installation path of pkgconfig file.

### DIFF
--- a/md4c/CMakeLists.txt
+++ b/md4c/CMakeLists.txt
@@ -28,7 +28,7 @@ install(
 
 # Create a pkg-config file
 configure_file(md4c.pc.in md4c.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/md4c/md4c.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+install(FILES ${CMAKE_BINARY_DIR}/md4c/md4c.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # And a CMake file
 install(EXPORT md4cConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/md4c/)


### PR DESCRIPTION
If the package is compiled on a multiarch-enabled distribution (Debian and
derivatives) the resulting md4c.pc file will have a m-a path in it.

In this case it's better to install into LIBDIR.