### PR TITLE
Add missing <img /> tag for XHTML support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ New features:
  * With `MD_HTML_FLAG_XHTML`, The HTML renderer generates XHTML instead of
    HTML.
 
-   This effectively means `<br />` instead of `<br>` and similarly `<hr />`
-   instead of `<hr>`.
+   This effectively means `<br />` instead of `<br>`, `<hr />` instead of
+   `<hr>`, and `<img ... />` instead of `<img ...>`.
 
  * `md2html` utility now understands the flag `-x` or `--xhtml` to enable
    the XHTML mode.

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -356,7 +356,7 @@ render_close_img_span(MD_HTML* r, const MD_SPAN_IMG_DETAIL* det)
         render_attribute(r, &det->title, render_html_escaped);
     }
 
-    RENDER_VERBATIM(r, "\">");
+    RENDER_VERBATIM(r, (r->flags & MD_HTML_FLAG_XHTML) ? "\" />" : "\">");
 
     r->image_nesting_level--;
 }


### PR DESCRIPTION
While updating PyMD4C to support the new `MD_HTML_FLAG_XHTML` option, I noticed the `<img>` tag was left unchanged. This small PR makes the `<img>` tag self-close.