### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+pfft
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Temp files
+*.swp
+*.tmp
+*~
+~*
+*.e
+
+# autotools
+/aclocal.m4
+/autom4te.cache/
+/build-aux/
+conf*.dir/
+/config.h
+/config.log
+/config.status
+/configure
+.deps/
+.dirstamp
+Makefile
+Makefile.in
+stamp-*
+*.stamp
+*.stamp-*
+.Tpo


### PR DESCRIPTION
Thank you for this project, which I have just started using and which seems very useful!  I noticed that compiling md4c dirties the Git repo, so I added a .gitignore file.  I submit it here in hopes it will be helpful to you or others.  Thanks for considering this PR!

Note on sources: the .gitignore is mostly the [GitHub C gitignore](https://github.com/github/gitignore/blob/master/C.gitignore).  I have added some lines for autotools, since I am using autotools to build a project that uses md4c as a submodule.  

Notes on contents: `Makefile` is ignored.  I think this is OK since you are using CMake instead of make, but I am happy to change it if you prefer.  I can also add `/build/` if you want that, since that's the CMake build dir for Travis.  

Please let me know if you have any questions or comments.  Thank you!