### PR TITLE
added power support arch ppc64le on YML file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # YAML definition for travis-ci.com continuous integration.
 # See https://docs.travis-ci.com/user/languages/c
-
+arch:
+    - amd64
+    - ppc64le
 language: c
 dist: bionic
 


### PR DESCRIPTION
Hi team,
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build has passed after adding power support arch without any failures.kindly check and close this component.

