### PR TITLE
Added fuzzer for oss-fuzz integration.

### DIFF
--- a/test/fuzzers/fuzz-mdhtml.c
+++ b/test/fuzzers/fuzz-mdhtml.c
@@ -1,0 +1,28 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include "md4c-html.h"
+
+static void
+process_output(const MD_CHAR* text, MD_SIZE size, void* userdata)
+{
+   /* This is  dummy function because we dont need any processing on the data */
+   return;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    if (size < 8) {
+        return 0;
+    }
+
+    unsigned int parser_flags = *(unsigned int*)data;
+    data += 4; size -= 4;
+    unsigned int renderer_flags = *(unsigned int*)data;
+    data += 4; size -= 4;
+
+    /* Allocate enough space */
+    char *out = malloc(size*3);
+    md_html(data, size, process_output, out, parser_flags, renderer_flags);
+    free(out);
+
+    return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for md4c by way of OSS-Fuzz. https://github.com/google/oss-fuzz/pull/5242 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate md4c. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I stored the fuzzers (in the PR I linked) in the Google OSS-Fuzz repository, but we can move them up here to make maintenance easier.

I noticed that you had previously asked if MD4C is qualified https://github.com/google/oss-fuzz/issues/2134 and I believe following the QT integration it should be ready now!