### PR TITLE
Fix for a buffer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Changes:
 
 Fixes:
 
+ * [#167](https://github.com/mity/md4c/issues/167):
+   Fix two buffer overflow bugs found using a fuzz testting. Contributed by
+   dtldarek.
+
  * [#163](https://github.com/mity/md4c/issues/163):
    Make HTML renderer to emit `'\n'` after the root tag when in the XHTML mode.
 

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5685,6 +5685,7 @@ md_is_container_mark(MD_CTX* ctx, unsigned indent, OFF beg, OFF* p_end, MD_CONTA
         off++;
     }
     if(off > beg  &&
+       off < ctx->size  &&
        (CH(off) == _T('.') || CH(off) == _T(')'))  &&
        (off+1 >= ctx->size || ISBLANK(off+1) || ISNEWLINE(off+1)))
     {

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2275,7 +2275,7 @@ md_is_inline_link_spec(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
     /* Optional white space with up to one line break. */
     while(off < lines[line_index].end  &&  ISWHITESPACE(off))
         off++;
-    if(off >= lines[line_index].end  &&  ISNEWLINE(off)) {
+    if(off >= lines[line_index].end  &&  (off >= ctx->size  ||  ISNEWLINE(off))) {
         line_index++;
         if(line_index >= n_lines)
             return FALSE;


### PR DESCRIPTION
Fuzzying found that input `"\xA9##r[](r[]("` generates a buffer overflow (see the diff for the exact place), and this is a small change that should fix it.