### PR TITLE
docs: fix simple typo, propgated -> propagated

### DIFF
--- a/src/md4c-html.h
+++ b/src/md4c-html.h
@@ -49,7 +49,7 @@
  * Callback process_output() gets called with chunks of HTML output.
  * (Typical implementation may just output the bytes to a file or append to
  * some buffer).
- * Param userdata is just propgated back to process_output() callback.
+ * Param userdata is just propagated back to process_output() callback.
  * Param parser_flags are flags from md4c.h propagated to md_parse().
  * Param render_flags is bitmask of MD_HTML_FLAG_xxxx.
  *


### PR DESCRIPTION
There is a small typo in src/md4c-html.h.

Should read `propagated` rather than `propgated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md