### PR TITLE
Add option `MD_FLAG_HARD_SOFT_BREAKS`

### DIFF
--- a/md2html/md2html.1
+++ b/md2html/md2html.1
@@ -78,6 +78,9 @@ Allow e-mail autolinks without "<", ">" and "mailto:"
 .TP
 .B --fpermissive-autolinks
 Enable all 3 of the above permissive autolinks options
+.TP
+.B --fhard-soft-breaks
+Force all soft breaks to act as hard breaks
 .
 .TP
 .B --fno-indented-code

--- a/md2html/md2html.c
+++ b/md2html/md2html.c
@@ -211,6 +211,7 @@ static const CMDLINE_OPTION cmdline_options[] = {
     {  0,  "flatex-math",                   'L', 0 },
     {  0,  "fpermissive-atx-headers",       'A', 0 },
     {  0,  "fpermissive-autolinks",         'V', 0 },
+    {  0,  "fhard-soft-breaks",             'B', 0 },
     {  0,  "fpermissive-email-autolinks",   '@', 0 },
     {  0,  "fpermissive-url-autolinks",     'U', 0 },
     {  0,  "fpermissive-www-autolinks",     '.', 0 },
@@ -264,6 +265,8 @@ usage(void)
         "      --fpermissive-autolinks\n"
         "                       Same as --fpermissive-url-autolinks --fpermissive-www-autolinks\n"
         "                       --fpermissive-email-autolinks\n"
+        "      --fhard-soft-breaks\n"
+        "                       Force all soft breaks to act as hard breaks\n"
         "      --fstrikethrough Enable strike-through spans\n"
         "      --ftables        Enable tables\n"
         "      --ftasklists     Enable task lists\n"
@@ -335,6 +338,7 @@ cmdline_callback(int opt, char const* value, void* data)
         case 'K':   parser_flags |= MD_FLAG_WIKILINKS; break;
         case 'X':   parser_flags |= MD_FLAG_TASKLISTS; break;
         case '_':   parser_flags |= MD_FLAG_UNDERLINE; break;
+        case 'B':   parser_flags |= MD_FLAG_HARD_SOFT_BREAKS; break;
 
         default:
             fprintf(stderr, "Illegal option: %s\n", value);

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -47,6 +47,10 @@ echo "WWW autolinks extension:"
 $PYTHON "$TEST_DIR/spec_tests.py" -s "$TEST_DIR/permissive-www-autolinks.txt" -p "$PROGRAM --fpermissive-www-autolinks"
 
 echo
+echo "Hard soft breaks extension:"
+$PYTHON "$TEST_DIR/spec_tests.py" -s "$TEST_DIR/hard-soft-breaks.txt" -p "$PROGRAM --fhard-soft-breaks"
+
+echo
 echo "Tables extension:"
 $PYTHON "$TEST_DIR/spec_tests.py" -s "$TEST_DIR/tables.txt" -p "$PROGRAM --ftables"
 

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4415,7 +4415,9 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
                 MD_TEXTTYPE break_type = MD_TEXT_SOFTBR;
 
                 if(text_type == MD_TEXT_NORMAL) {
-                    if(enforce_hardbreak)
+                    if(ctx->parser.flags & MD_FLAG_HARD_SOFT_BREAKS)
+                        break_type = MD_TEXT_BR;
+                    else if(enforce_hardbreak)
                         break_type = MD_TEXT_BR;
                     else if((CH(line->end) == _T(' ') && CH(line->end+1) == _T(' ')))
                         break_type = MD_TEXT_BR;

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -316,6 +316,7 @@ typedef struct MD_SPAN_WIKILINK {
 #define MD_FLAG_LATEXMATHSPANS              0x1000  /* Enable $ and $$ containing LaTeX equations. */
 #define MD_FLAG_WIKILINKS                   0x2000  /* Enable wiki links extension. */
 #define MD_FLAG_UNDERLINE                   0x4000  /* Enable underline extension (and disables '_' for normal emphasis). */
+#define MD_FLAG_HARD_SOFT_BREAKS            0x8000  /* Force all soft breaks to act as hard breaks. */
 
 #define MD_FLAG_PERMISSIVEAUTOLINKS         (MD_FLAG_PERMISSIVEEMAILAUTOLINKS | MD_FLAG_PERMISSIVEURLAUTOLINKS | MD_FLAG_PERMISSIVEWWWAUTOLINKS)
 #define MD_FLAG_NOHTML                      (MD_FLAG_NOHTMLBLOCKS | MD_FLAG_NOHTMLSPANS)

--- a/test/hard-soft-breaks.txt
+++ b/test/hard-soft-breaks.txt
@@ -1,0 +1,23 @@
+
+# Hard Soft Breaks
+
+With the flag `MD_FLAG_HARD_SOFT_BREAKS`, MD4C treats all newline characters as soft breaks.
+
+```````````````````````````````` example
+foo
+baz
+.
+<p>foo<br>
+baz</p>
+````````````````````````````````
+
+```````````````````````````````` example
+A quote from the CommonMark Spec below:
+
+A renderer may also provide an option to 
+render soft line breaks as hard line breaks.
+.
+<p>A quote from the CommonMark Spec below:</p>
+<p>A renderer may also provide an option to<br>
+render soft line breaks as hard line breaks.</p>
+````````````````````````````````


### PR DESCRIPTION
### [Soft Line Breaks - CommonMark Spec](https://spec.commonmark.org/0.30/#soft-line-breaks)

The ability to tread soft line breaks as hard line breaks is something specified in the spec, and highly needed for my project. Thank you for creating this library.