### PR TITLE
Fix leave callback not called for HTML block comment.

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -6080,7 +6080,7 @@ md_analyze_line(MD_CTX* ctx, OFF beg, OFF* p_end,
                 /* The line itself also may immediately close the block. */
                 if(md_is_html_block_end_condition(ctx, off, &off) == ctx->html_block_type) {
                     /* Make sure this is the last line of the block. */
-                    ctx->html_block_type = 0;
+                    ctx->html_block_type *= -1;
                 }
 
                 line->type = MD_LINE_HTML;
@@ -6244,7 +6244,11 @@ md_process_line(MD_CTX* ctx, const MD_LINE_ANALYSIS** p_pivot_line, MD_LINE_ANAL
     }
 
     /* Some line types form block on their own. */
-    if(line->type == MD_LINE_HR || line->type == MD_LINE_ATXHEADER) {
+    #define ONELINE_HTML_BLOCK_TYPE2 \
+      (line->type == MD_LINE_HTML && \
+       ctx->html_block_type == -2)
+    if(line->type == MD_LINE_HR || line->type == MD_LINE_ATXHEADER || ONELINE_HTML_BLOCK_TYPE2) {
+        #undef ONELINE_HTML_BLOCK_TYPE2
         MD_CHECK(md_end_current_block(ctx));
 
         /* Add our single-line block. */


### PR DESCRIPTION
For the specific case of a one-line block comment (HTML block type 2) not followed by a blank line[1], MD4C fails to call the leave callback. Consequently, if another HTML comment follows the first comment, both end up being combined into a single block instead of staying as two separate blocks, each with its own callback.

[1] In my comments to issue https://github.com/mity/md4c/issues/200 I remarked that the spec doesn't require a blank line to close a type 2 HTML block.

DETAILS

I can't think of a simple way to demonstrate this issue using md2html alone, precisely because the lack of something can't be shown. Feeding md2html the following markdown:

```
<!-- C1 -->
<!-- C2 -->
```

outputs the input text so one would be inclined to think that everything is correct. However, what can't be seen is that there is no callback between lines C1 and C2, while there should be one. Instead, a callback after line C2 wrongly combines the two single-line blocks into a two-line block. Trace the code or add printf statements as needed to see the issue at work.

This commit fixes the problem by setting `ctx->html_block_type` to a negative value as a special way to flag this end-of-block case.