### PR TITLE
Fix code span wrongly identified as code block

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -6058,7 +6058,7 @@ md_analyze_line(MD_CTX* ctx, OFF beg, OFF* p_end,
         }
 
         /* Check whether we are starting code fence. */
-        if(off < ctx->size  &&  ISANYOF2(off, _T('`'), _T('~'))) {
+        if(off < ctx->size  && line->indent <= 3 &&  ISANYOF2(off, _T('`'), _T('~'))) {
             if(md_is_opening_code_fence(ctx, off, &off)) {
                 line->type = MD_LINE_FENCEDCODE;
                 line->data = 1;


### PR DESCRIPTION
Close https://github.com/mity/md4c/issues/201.

What happens in #201 is that MD4C identifies the first "```" as the start of a fenced code block.

Threfore it renders "aaa" and "    ```" as code block lines, then it
automatically closes the fenced code block at EOF.

DETAILS

Commonmark spec 0.30 about fenced code blocks.

A fenced code block begins with a code fence, preceded by up to three spaces of indentation.[1]
A fenced code block may interrupt a paragraph, and does not require a blank line either before or after.[2]

- [1] https://github.com/commonmark/commonmark-spec/blob/d5706b9553d4665ca730524323d484880440186c/spec.txt#L1940
- [2] https://github.com/commonmark/commonmark-spec/blob/d5706b9553d4665ca730524323d484880440186c/spec.txt#L1969