### PR TITLE
Don't trim HTML block lines (MD_LINE_HTML)

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -6182,7 +6182,7 @@ md_analyze_line(MD_CTX* ctx, OFF beg, OFF* p_end,
     }
 
     /* Trim trailing spaces. */
-    if(line->type != MD_LINE_INDENTEDCODE  &&  line->type != MD_LINE_FENCEDCODE) {
+    if(line->type != MD_LINE_INDENTEDCODE  &&  line->type != MD_LINE_FENCEDCODE  && line->type != MD_LINE_HTML) {
         while(line->end > line->beg && CH(line->end-1) == _T(' '))
             line->end--;
     }


### PR DESCRIPTION
Markdown 0.30 doesn't mandate right-trimming the contents of HTML lines. Doing so is more work and breaks output compatibility with cmark, tested with https://github.com/commonmark/cmark/commit/9393560.