### PR TITLE
Improve/unify approach to line indexing.

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -496,10 +496,10 @@ md_text_with_null_replacement(MD_CTX* ctx, MD_TEXTTYPE type, const CHAR* str, SZ
 /* If the offset falls into a gap between line, we return the following
  * line. */
 static const MD_LINE*
-md_lookup_line(OFF off, const MD_LINE* lines, int n_lines)
+md_lookup_line(OFF off, const MD_LINE* lines, MD_SIZE n_lines, MD_SIZE* p_line_index)
 {
-    int lo, hi;
-    int pivot;
+    MD_SIZE lo, hi;
+    MD_SIZE pivot;
     const MD_LINE* line;
 
     lo = 0;
@@ -509,12 +509,17 @@ md_lookup_line(OFF off, const MD_LINE* lines, int n_lines)
         line = &lines[pivot];
 
         if(off < line->beg) {
-            hi = pivot - 1;
-            if(hi < 0  ||  lines[hi].end <= off)
+            if(hi == 0  ||  lines[hi-1].end < off) {
+                if(p_line_index != NULL)
+                    *p_line_index = pivot;
                 return line;
+            }
+            hi = pivot - 1;
         } else if(off > line->end) {
             lo = pivot + 1;
         } else {
+            if(p_line_index != NULL)
+                *p_line_index = pivot;
             return line;
         }
     }
@@ -954,7 +959,7 @@ struct MD_UNICODE_FOLD_INFO_tag {
  * what the caller should allocate.)
  */
 static void
-md_merge_lines(MD_CTX* ctx, OFF beg, OFF end, const MD_LINE* lines, int n_lines,
+md_merge_lines(MD_CTX* ctx, OFF beg, OFF end, const MD_LINE* lines, MD_SIZE n_lines,
                CHAR line_break_replacement_char, CHAR* buffer, SZ* p_size)
 {
     CHAR* ptr = buffer;
@@ -991,7 +996,7 @@ md_merge_lines(MD_CTX* ctx, OFF beg, OFF end, const MD_LINE* lines, int n_lines,
 /* Wrapper of md_merge_lines() which allocates new buffer for the output string.
  */
 static int
-md_merge_lines_alloc(MD_CTX* ctx, OFF beg, OFF end, const MD_LINE* lines, int n_lines,
+md_merge_lines_alloc(MD_CTX* ctx, OFF beg, OFF end, const MD_LINE* lines, MD_SIZE n_lines,
                     CHAR line_break_replacement_char, CHAR** p_str, SZ* p_size)
 {
     CHAR* buffer;
@@ -1038,12 +1043,12 @@ md_skip_unicode_whitespace(const CHAR* label, OFF off, SZ size)
  * by n_lines == 0.
  */
 static int
-md_is_html_tag(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_tag(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     int attr_state;
     OFF off = beg;
     OFF line_end = (n_lines > 0) ? lines[0].end : ctx->size;
-    int i = 0;
+    MD_SIZE line_index = 0;
 
     MD_ASSERT(CH(beg) == _T('<'));
 
@@ -1133,12 +1138,12 @@ md_is_html_tag(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_
         if(n_lines == 0)
             return FALSE;
 
-        i++;
-        if(i >= n_lines)
+        line_index++;
+        if(line_index >= n_lines)
             return FALSE;
 
-        off = lines[i].beg;
-        line_end = lines[i].end;
+        off = lines[line_index].beg;
+        line_end = lines[line_index].end;
 
         if(attr_state == 0  ||  attr_state == 41)
             attr_state = 1;
@@ -1157,12 +1162,12 @@ done:
 
 static int
 md_scan_for_html_closer(MD_CTX* ctx, const MD_CHAR* str, MD_SIZE len,
-                        const MD_LINE* lines, int n_lines,
+                        const MD_LINE* lines, MD_SIZE n_lines,
                         OFF beg, OFF max_end, OFF* p_end,
                         OFF* p_scan_horizon)
 {
     OFF off = beg;
-    int i = 0;
+    MD_SIZE line_index = 0;
 
     if(off < *p_scan_horizon  &&  *p_scan_horizon >= max_end - len) {
         /* We have already scanned the range up to the max_end so we know
@@ -1171,7 +1176,7 @@ md_scan_for_html_closer(MD_CTX* ctx, const MD_CHAR* str, MD_SIZE len,
     }
 
     while(TRUE) {
-        while(off + len <= lines[i].end  &&  off + len <= max_end) {
+        while(off + len <= lines[line_index].end  &&  off + len <= max_end) {
             if(md_ascii_eq(STR(off), str, len)) {
                 /* Success. */
                 *p_end = off + len;
@@ -1180,19 +1185,19 @@ md_scan_for_html_closer(MD_CTX* ctx, const MD_CHAR* str, MD_SIZE len,
             off++;
         }
 
-        i++;
-        if(off >= max_end  ||  i >= n_lines) {
+        line_index++;
+        if(off >= max_end  ||  line_index >= n_lines) {
             /* Failure. */
             *p_scan_horizon = off;
             return FALSE;
         }
 
-        off = lines[i].beg;
+        off = lines[line_index].beg;
     }
 }
 
 static int
-md_is_html_comment(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_comment(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     OFF off = beg;
 
@@ -1225,7 +1230,7 @@ md_is_html_comment(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF 
 }
 
 static int
-md_is_html_processing_instruction(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_processing_instruction(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     OFF off = beg;
 
@@ -1240,7 +1245,7 @@ md_is_html_processing_instruction(MD_CTX* ctx, const MD_LINE* lines, int n_lines
 }
 
 static int
-md_is_html_declaration(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_declaration(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     OFF off = beg;
 
@@ -1262,7 +1267,7 @@ md_is_html_declaration(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, 
 }
 
 static int
-md_is_html_cdata(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_cdata(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     static const CHAR open_str[] = _T("<![CDATA[");
     static const SZ open_size = SIZEOF_ARRAY(open_str) - 1;
@@ -1280,7 +1285,7 @@ md_is_html_cdata(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF ma
 }
 
 static int
-md_is_html_any(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg, OFF max_end, OFF* p_end)
+md_is_html_any(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg, OFF max_end, OFF* p_end)
 {
     MD_ASSERT(CH(beg) == _T('<'));
     return (md_is_html_tag(ctx, lines, n_lines, beg, max_end, p_end)  ||
@@ -1908,14 +1913,14 @@ struct MD_LINK_ATTR_tag {
 
 
 static int
-md_is_link_label(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg,
-                 OFF* p_end, int* p_beg_line_index, int* p_end_line_index,
+md_is_link_label(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg,
+                 OFF* p_end, MD_SIZE* p_beg_line_index, MD_SIZE* p_end_line_index,
                  OFF* p_contents_beg, OFF* p_contents_end)
 {
     OFF off = beg;
     OFF contents_beg = 0;
     OFF contents_end = 0;
-    int line_index = 0;
+    MD_SIZE line_index = 0;
     int len = 0;
 
     if(CH(off) != _T('['))
@@ -2065,13 +2070,13 @@ md_is_link_destination(MD_CTX* ctx, OFF beg, OFF max_end, OFF* p_end,
 }
 
 static int
-md_is_link_title(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg,
-                 OFF* p_end, int* p_beg_line_index, int* p_end_line_index,
+md_is_link_title(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg,
+                 OFF* p_end, MD_SIZE* p_beg_line_index, MD_SIZE* p_end_line_index,
                  OFF* p_contents_beg, OFF* p_contents_end)
 {
     OFF off = beg;
     CHAR closer_char;
-    int line_index = 0;
+    MD_SIZE line_index = 0;
 
     /* White space with up to one line break. */
     while(off < lines[line_index].end  &&  ISWHITESPACE(off))
@@ -2133,21 +2138,21 @@ md_is_link_title(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg,
  * Returns -1 in case of an error (out of memory).
  */
 static int
-md_is_link_reference_definition(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
+md_is_link_reference_definition(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 {
     OFF label_contents_beg;
     OFF label_contents_end;
-    int label_contents_line_index = -1;
+    MD_SIZE label_contents_line_index;
     int label_is_multiline = FALSE;
     OFF dest_contents_beg;
     OFF dest_contents_end;
     OFF title_contents_beg;
     OFF title_contents_end;
-    int title_contents_line_index;
+    MD_SIZE title_contents_line_index;
     int title_is_multiline = FALSE;
     OFF off;
-    int line_index = 0;
-    int tmp_line_index;
+    MD_SIZE line_index = 0;
+    MD_SIZE tmp_line_index;
     MD_REF_DEF* def = NULL;
     int ret = 0;
 
@@ -2255,7 +2260,7 @@ abort:
 }
 
 static int
-md_is_link_reference(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
+md_is_link_reference(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                      OFF beg, OFF end, MD_LINK_ATTR* attr)
 {
     const MD_REF_DEF* def;
@@ -2272,7 +2277,7 @@ md_is_link_reference(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
     end--;
 
     /* Find lines corresponding to the beg and end positions. */
-    beg_line = md_lookup_line(beg, lines, n_lines);
+    beg_line = md_lookup_line(beg, lines, n_lines, NULL);
     is_multiline = (end > beg_line->end);
 
     if(is_multiline) {
@@ -2302,14 +2307,14 @@ abort:
 }
 
 static int
-md_is_inline_link_spec(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
+md_is_inline_link_spec(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                        OFF beg, OFF* p_end, MD_LINK_ATTR* attr)
 {
-    int line_index = 0;
-    int tmp_line_index;
+    MD_SIZE line_index = 0;
+    MD_SIZE tmp_line_index;
     OFF title_contents_beg;
     OFF title_contents_end;
-    int title_contents_line_index;
+    MD_SIZE title_contents_line_index;
     int title_is_multiline;
     OFF off = beg;
     int ret = FALSE;
@@ -2737,7 +2742,7 @@ md_build_mark_char_map(MD_CTX* ctx)
 }
 
 static int
-md_is_code_span(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg,
+md_is_code_span(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg,
                 MD_MARK* opener, MD_MARK* closer,
                 OFF last_potential_closers[CODESPAN_MARK_MAXLEN],
                 int* p_reached_paragraph_end)
@@ -2753,7 +2758,7 @@ md_is_code_span(MD_CTX* ctx, const MD_LINE* lines, int n_lines, OFF beg,
     int has_space_before_closer = FALSE;
     int has_eol_before_closer = FALSE;
     int has_only_space = TRUE;
-    int line_index = 0;
+    MD_SIZE line_index = 0;
 
     line_end = lines[0].end;
     opener_end = opener_beg;
@@ -2964,16 +2969,16 @@ md_is_autolink(MD_CTX* ctx, OFF beg, OFF max_end, OFF* p_end, int* p_missing_mai
 }
 
 static int
-md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
+md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, int table_mode)
 {
-    const MD_LINE* line_term = lines + n_lines;
-    const MD_LINE* line;
+    MD_SIZE line_index;
     int ret = 0;
     MD_MARK* mark;
     OFF codespan_last_potential_closers[CODESPAN_MARK_MAXLEN] = { 0 };
     int codespan_scanned_till_paragraph_end = FALSE;
 
-    for(line = lines; line < line_term; line++) {
+    for(line_index = 0; line_index < n_lines; line_index++) {
+        const MD_LINE* line = &lines[line_index];
         OFF off = line->beg;
 
         while(TRUE) {
@@ -3005,7 +3010,7 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
              * line to form a hard break. */
             if(ch == _T('\\')  &&  off+1 < ctx->size  &&  (ISPUNCT(off+1) || ISNEWLINE(off+1))) {
                 /* Hard-break cannot be on the last line of the block. */
-                if(!ISNEWLINE(off+1)  ||  line+1 < line_term)
+                if(!ISNEWLINE(off+1)  ||  line_index+1 < n_lines)
                     ADD_MARK(ch, off, off+2, MD_MARK_RESOLVED);
                 off += 2;
                 continue;
@@ -3084,7 +3089,7 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
                 MD_MARK closer;
                 int is_code_span;
 
-                is_code_span = md_is_code_span(ctx, line, line_term - line, off,
+                is_code_span = md_is_code_span(ctx, line, n_lines - line_index, off,
                             &opener, &closer, codespan_last_potential_closers,
                             &codespan_scanned_till_paragraph_end);
                 if(is_code_span) {
@@ -3095,7 +3100,7 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
 
                     /* Advance the current line accordingly. */
                     if(off > line->end)
-                        line = md_lookup_line(off, line, line_term - line);
+                        line = md_lookup_line(off, lines, n_lines, &line_index);
                     continue;
                 }
 
@@ -3133,7 +3138,7 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
                     /* Given the nature of the raw HTML, we have to recognize
                      * it here. Doing so later in md_analyze_lt_gt() could
                      * open can of worms of quadratic complexity. */
-                    is_html = md_is_html_any(ctx, line, line_term - line, off,
+                    is_html = md_is_html_any(ctx, line, n_lines - line_index, off,
                                     lines[n_lines-1].end, &html_end);
                     if(is_html) {
                         ADD_MARK(_T('<'), off, off, MD_MARK_OPENER | MD_MARK_RESOLVED);
@@ -3144,7 +3149,7 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
 
                         /* Advance the current line accordingly. */
                         if(off > line->end)
-                            line = md_lookup_line(off, line, line_term - line);
+                            line = md_lookup_line(off, lines, n_lines, &line_index);
                         continue;
                     }
                 }
@@ -3384,11 +3389,11 @@ md_analyze_bracket(MD_CTX* ctx, int mark_index)
 }
 
 /* Forward declaration. */
-static void md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
+static void md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                                      int mark_beg, int mark_end);
 
 static int
-md_resolve_links(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
+md_resolve_links(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 {
     int opener_index = ctx->unresolved_link_head;
     OFF last_link_beg = 0;
@@ -4023,7 +4028,7 @@ md_analyze_permissive_autolink(MD_CTX* ctx, int mark_index)
 #define MD_ANALYZE_NOSKIP_EMPH  0x01
 
 static inline void
-md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
+md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                  int mark_beg, int mark_end, const CHAR* mark_chars, unsigned flags)
 {
     int i = mark_beg;
@@ -4089,7 +4094,7 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
 
 /* Analyze marks (build ctx->marks). */
 static int
-md_analyze_inlines(MD_CTX* ctx, const MD_LINE* lines, int n_lines, int table_mode)
+md_analyze_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, int table_mode)
 {
     int ret;
 
@@ -4122,7 +4127,7 @@ abort:
 }
 
 static void
-md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, int n_lines,
+md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                          int mark_beg, int mark_end)
 {
     int i;
@@ -4193,7 +4198,7 @@ abort:
 
 /* Render the output, accordingly to the analyzed ctx->marks. */
 static int
-md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
+md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 {
     MD_TEXTTYPE text_type;
     const MD_LINE* line = lines;
@@ -4513,7 +4518,7 @@ md_analyze_table_alignment(MD_CTX* ctx, OFF beg, OFF end, MD_ALIGN* align, int n
 }
 
 /* Forward declaration. */
-static int md_process_normal_block_contents(MD_CTX* ctx, const MD_LINE* lines, int n_lines);
+static int md_process_normal_block_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines);
 
 static int
 md_process_table_cell(MD_CTX* ctx, MD_BLOCKTYPE cell_type, MD_ALIGN align, OFF beg, OFF end)
@@ -4595,10 +4600,10 @@ abort:
 }
 
 static int
-md_process_table_block_contents(MD_CTX* ctx, int col_count, const MD_LINE* lines, int n_lines)
+md_process_table_block_contents(MD_CTX* ctx, int col_count, const MD_LINE* lines, MD_SIZE n_lines)
 {
     MD_ALIGN* align;
-    int i;
+    MD_SIZE line_index;
     int ret = 0;
 
     /* At least two lines have to be present: The column headers and the line
@@ -4621,9 +4626,9 @@ md_process_table_block_contents(MD_CTX* ctx, int col_count, const MD_LINE* lines
 
     if(n_lines > 2) {
         MD_ENTER_BLOCK(MD_BLOCK_TBODY, NULL);
-        for(i = 2; i < n_lines; i++) {
+        for(line_index = 2; line_index < n_lines; line_index++) {
             MD_CHECK(md_process_table_row(ctx, MD_BLOCK_TD,
-                     lines[i].beg, lines[i].end, align, col_count));
+                     lines[line_index].beg, lines[line_index].end, align, col_count));
         }
         MD_LEAVE_BLOCK(MD_BLOCK_TBODY, NULL);
     }
@@ -4659,7 +4664,7 @@ struct MD_BLOCK_tag {
      * MD_BLOCK_LI:     Task mark offset in the input doc.
      * MD_BLOCK_OL:     Start item number.
      */
-    unsigned n_lines;
+    MD_SIZE n_lines;
 };
 
 struct MD_CONTAINER_tag {
@@ -4675,7 +4680,7 @@ struct MD_CONTAINER_tag {
 
 
 static int
-md_process_normal_block_contents(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
+md_process_normal_block_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 {
     int i;
     int ret;
@@ -4693,16 +4698,16 @@ abort:
 }
 
 static int
-md_process_verbatim_block_contents(MD_CTX* ctx, MD_TEXTTYPE text_type, const MD_VERBATIMLINE* lines, int n_lines)
+md_process_verbatim_block_contents(MD_CTX* ctx, MD_TEXTTYPE text_type, const MD_VERBATIMLINE* lines, MD_SIZE n_lines)
 {
     static const CHAR indent_chunk_str[] = _T("                ");
     static const SZ indent_chunk_size = SIZEOF_ARRAY(indent_chunk_str) - 1;
 
-    int i;
+    MD_SIZE line_index;
     int ret = 0;
 
-    for(i = 0; i < n_lines; i++) {
-        const MD_VERBATIMLINE* line = &lines[i];
+    for(line_index = 0; line_index < n_lines; line_index++) {
+        const MD_VERBATIMLINE* line = &lines[line_index];
         int indent = line->indent;
 
         MD_ASSERT(indent >= 0);
@@ -4727,7 +4732,7 @@ abort:
 }
 
 static int
-md_process_code_block_contents(MD_CTX* ctx, int is_fenced, const MD_VERBATIMLINE* lines, int n_lines)
+md_process_code_block_contents(MD_CTX* ctx, int is_fenced, const MD_VERBATIMLINE* lines, MD_SIZE n_lines)
 {
     if(is_fenced) {
         /* Skip the first line in case of fenced code: It is the fence.
@@ -5054,8 +5059,8 @@ static int
 md_consume_link_reference_definitions(MD_CTX* ctx)
 {
     MD_LINE* lines = (MD_LINE*) (ctx->current_block + 1);
-    int n_lines = ctx->current_block->n_lines;
-    int n = 0;
+    MD_SIZE n_lines = ctx->current_block->n_lines;
+    MD_SIZE n = 0;
 
     /* Compute how many lines at the start of the block form one or more
      * reference definitions. */
@@ -5118,7 +5123,7 @@ md_end_current_block(MD_CTX* ctx)
     }
 
     if(ctx->current_block->type == MD_BLOCK_H  &&  (ctx->current_block->flags & MD_BLOCK_SETEXT_HEADER)) {
-        int n_lines = ctx->current_block->n_lines;
+        MD_SIZE n_lines = ctx->current_block->n_lines;
 
         if(n_lines > 1) {
             /* Get rid of the underline. */


### PR DESCRIPTION
This PR is an alternative solution to issue addressed in #232.

* Use consistently type `MD_SIZE` for line indeces.
* Remove pointer arithmetic if lines and replace it with line index arithmetic.

This resolves some warnings in MSVC builds.