### PR TITLE
Introduce an overall limit to link. ref. defs instantiations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Fixes:
    Fix quadratic time behavior caused by one-by-one walking over block lines
    instead of calling `md_lookup_line()`.
 
+ - [#237](https://github.com/mity/md4c/issues/237):
+   Fix quadratic time and output size behavior caused by malicious misuse of
+   link reference definitions.
+
 
 ## Version 0.5.2
 

--- a/test/pathological-tests.py
+++ b/test/pathological-tests.py
@@ -102,7 +102,10 @@ pathological = {
             "--ftables"),
     "many broken links":
             (("]([\n" * 50000),
-            re.compile("<p>(\]\(\[\r?\n){49999}\]\(\[</p>"))
+            re.compile("<p>(\]\(\[\r?\n){49999}\]\(\[</p>")),
+    "many link ref. def. instantiations":
+            (("[x]: " + "x" * 50000 + "\n[x]" * 50000),
+            re.compile(""))
 }
 
 whitespace_re = re.compile('/s+/')


### PR DESCRIPTION
This is to prevent time and output size explosion in case of input pattern generated by this:

```
$ python -c 'N=1000; print("[x]: " + "x" * N + "\n[x]" * N)'
```

We roughly allow to blowing up the input size of the document 16 times by link reference definitions or up to 1 MB, whatever is smaller. When the threshold is reached, following reference definitions are sent to output unresolved as a text.

Fixes #238.