### PR TITLE
Add a reference lnav in the list of software that uses md4c

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,6 @@ Software using MD4C:
 
 * [8th](https://8th-dev.com/):
   Cross-platform concatenative programming language.
+  
+* [lnav](https://lnav.org/):
+  A log file viewer for the terminal that can also render markdown.


### PR DESCRIPTION
The Logfile Navigator (https://lnav.org) is a viewer for the terminal that can also render markdown files.