### PR TITLE
Add build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,19 +28,15 @@ pub fn build(b: *std.Build) !void {
         with_utf8 = true;
     }
 
-    const lib = if (build_shared)
-        b.addSharedLibrary(.{
-            .name = "md4c",
+    const lib = b.addLibrary(.{
+        .name = "md4c",
+        .version = VERSION,
+        .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
-            .version = VERSION,
-        })
-    else
-        b.addStaticLibrary(.{
-            .name = "md4c",
-            .target = target,
-            .optimize = optimize,
-        });
+        }),
+        .linkage = if (build_shared) .dynamic else .static,
+    });
 
     lib.addCSourceFiles(.{
         .files = &md4c_sources,
@@ -54,8 +50,10 @@ pub fn build(b: *std.Build) !void {
 
     const exe = b.addExecutable(.{
         .name = "md2html",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     setDefines(exe, with_utf8, with_utf16, with_ascii);

--- a/build.zig
+++ b/build.zig
@@ -90,11 +90,11 @@ fn setDefines(
     );
 
     if (with_utf8) {
-        lib_or_exe.defineCMacro("MD4C_USE_UTF8", "1");
+        lib_or_exe.root_module.addCMacro("MD4C_USE_UTF8", "1");
     } else if (with_ascii) {
-        lib_or_exe.defineCMacro("MD4C_USE_ASCII", "1");
+        lib_or_exe.root_module.addCMacro("MD4C_USE_ASCII", "1");
     } else if (with_utf16) {
-        lib_or_exe.defineCMacro("MD4C_USE_UTF16", "1");
+        lib_or_exe.root_module.addCMacro("MD4C_USE_UTF16", "1");
     }
 }
 

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const shared = b.option(
+        bool,
+        "shared",
+        "Build wd4c as a shared library",
+    ) orelse false;
+
+    const lib = if (shared)
+        b.addSharedLibrary(.{
+            .name = "md4c",
+            .target = target,
+            .optimize = optimize,
+            .version = .{ .major = 0, .minor = 4, .patch = 9 },
+        })
+    else
+        b.addStaticLibrary(.{
+            .name = "md4c",
+            .target = target,
+            .optimize = optimize,
+        });
+
+    lib.defineCMacro("MD4C_USE_UTF8", "");
+    lib.addCSourceFiles(.{
+        .files = &md4c_sources,
+        .flags = &md4c_flags,
+    });
+    lib.linkLibC();
+    lib.installHeader("src/md4c.h", "md4c.h");
+
+    b.installArtifact(lib);
+}
+
+const md4c_flags = [_][]const u8{
+    "-Wall",
+};
+
+const md4c_sources = [_][]const u8{
+    "src/md4c.c",
+};

--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,11 @@ pub fn build(b: *std.Build) !void {
 
     // On Windows, given there is no standard lib install dir etc., we rather
     // by default build static lib.
-    const build_shared = !target.result.isMinGW();
+    const build_shared = b.option(
+        bool,
+        "md4c-shared",
+        "Build md4c as a shared library",
+    ) orelse !target.result.isMinGW();
 
     // build options
     var with_utf8 = b.option(bool, "utf8", "Use UTF8") orelse false;

--- a/build.zig
+++ b/build.zig
@@ -49,7 +49,7 @@ pub fn build(b: *std.Build) !void {
 
     setDefines(lib, with_utf8, with_utf16, with_ascii);
     lib.linkLibC();
-    lib.installHeader(.{ .path = "src/md4c.h" }, "md4c.h");
+    lib.installHeader(b.path("src/md4c.h"), "md4c.h");
     b.installArtifact(lib);
 
     const exe = b.addExecutable(.{

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -164,7 +164,7 @@ typedef enum MD_TEXTTYPE {
     MD_TEXT_SOFTBR,     /* '\n' in source text where it is not semantically meaningful (soft break) */
 
     /* Entity.
-     * (a) Named entity, e.g. &nbsp; 
+     * (a) Named entity, e.g. &nbsp;
      *     (Note MD4C does not have a list of known entities.
      *     Anything matching the regexp /&[A-Za-z][A-Za-z0-9]{1,47};/ is
      *     treated as a named entity.)


### PR DESCRIPTION
Hi! `md4c` is brilliant and I am using it in some of my little [Zig](https://github.com/ziglang/) projects. To make my life easier, I forked and added a `build.zig` so that it's easy for my Zig projects to use `md4c`.

I thought I might contribute it back, as other Zig users might also be interested in making their lives a little easier too. I wrote the script so that it mimics the CMake build.

You can then build `md4c` with
```bash
zig build
```
or build `md2html` with
```bash
zig build md2html
```

This will compile the following
```
zig-out
├── bin
│   └── md2html
├── include
│   └── md4c.h
└── lib
    ├── libmd4c.so -> libmd4c.so.0
    ├── libmd4c.so.0 -> libmd4c.so.0.4.8
    └── libmd4c.so.0.4.8
```

In using Zig, you get easy cross-compilation for free too :)

Hope this is useful, and thanks for the fantastic library!
