### PR TITLE
Fix md_decode_utf16le_before__() return value

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -855,7 +855,7 @@ struct MD_UNICODE_FOLD_INFO_tag {
         if(off > 2 && IS_UTF16_SURROGATE_HI(CH(off-2)) && IS_UTF16_SURROGATE_LO(CH(off-1)))
             return UTF16_DECODE_SURROGATE(CH(off-2), CH(off-1));
 
-        return CH(off);
+        return CH(off-1);
     }
 
     /* No whitespace uses surrogates, so no decoding needed here. */


### PR DESCRIPTION
I believe `md_decode_utf16le_before__()` returns the wrong value. The function is supposed to return the character before the offset. We can compare with the utf8 version [`md_decode_utf8_before__()`](https://github.com/mity/md4c/blob/481fbfbdf72daab2912380d62bb5f2187d438408/src/md4c.c#L921) which returns `CH(off-1)`.

Closes https://github.com/mity/md4c/issues/275