### PR TITLE
fix tasklist XHTML render

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -286,9 +286,12 @@ render_open_li_block(MD_HTML* r, const MD_BLOCK_LI_DETAIL* det)
     if(det->is_task) {
         RENDER_VERBATIM(r, "<li class=\"task-list-item\">"
                           "<input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled");
-        if(det->task_mark == 'x' || det->task_mark == 'X')
+        if(r->flags & MD_HTML_FLAG_XHTML) RENDER_VERBATIM(r, "=\"true\"");
+        if(det->task_mark == 'x' || det->task_mark == 'X') {
             RENDER_VERBATIM(r, " checked");
-        RENDER_VERBATIM(r, ">");
+            if(r->flags & MD_HTML_FLAG_XHTML) RENDER_VERBATIM(r, "=\"true\"");
+        }
+        RENDER_VERBATIM(r, (r->flags & MD_HTML_FLAG_XHTML) ? " />" : ">");
     } else {
         RENDER_VERBATIM(r, "<li>");
     }


### PR DESCRIPTION
Currently the XHTML render of the following markdown

```markdown
- [ ] Is this valid XHTML?
- [x] Is this valid XHTML?
```

is

```html
<ul>
<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled>Is this valid XHTML?</li>
<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled checked>Is this valid XHTML?</li>
</ul>
```

which is not a valid XHTML. This PR adds check code to it which makes them valid XHTML.