### PR TITLE
fix OFF_MAX redefinition and a potential overflow

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -144,9 +144,6 @@
 #define SZ      MD_SIZE
 #define OFF     MD_OFFSET
 
-#define SZ_MAX      (sizeof(SZ) == 8 ? UINT64_MAX : UINT32_MAX)
-#define OFF_MAX     (sizeof(OFF) == 8 ? UINT64_MAX : UINT32_MAX)
-
 typedef struct MD_MARK_tag MD_MARK;
 typedef struct MD_BLOCK_tag MD_BLOCK;
 typedef struct MD_CONTAINER_tag MD_CONTAINER;
@@ -6466,7 +6463,7 @@ md_parse(const MD_CHAR* text, MD_SIZE size, const MD_PARSER* parser, void* userd
     ctx.code_indent_offset = (ctx.parser.flags & MD_FLAG_NOINDENTEDCODEBLOCKS) ? (OFF)(-1) : 4;
     md_build_mark_char_map(&ctx);
     ctx.doc_ends_with_newline = (size > 0  &&  ISNEWLINE_(text[size-1]));
-    ctx.max_ref_def_output = MIN(MIN(16 * (uint64_t)size, (uint64_t)(1024 * 1024)), (uint64_t)SZ_MAX);
+    ctx.max_ref_def_output = 16 * MIN(size, (MD_SIZE)(1024 * 1024 / 16));
 
     /* Reset all mark stacks and lists. */
     for(i = 0; i < (int) SIZEOF_ARRAY(ctx.opener_stacks); i++)


### PR DESCRIPTION
This addresses first two points of issue #281.

- Since `OFF_MAX` is not used in the code at all, I just remove it.
- `SZ_MAX` is used only at one place in the code, and `1024 * 1024` is always smaller than it, so it seems redundant.
- `16 * size` could overflow, which makes the `MIN` returns `0` which is unwanted. I've changed the code such that if that happens, it also returns `1024 * 1024`.