### PR TITLE
Avoid repeated language- in info string.

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -301,7 +301,10 @@ render_open_code_block(MD_HTML* r, const MD_BLOCK_CODE_DETAIL* det)
 
     /* If known, output the HTML 5 attribute class="language-LANGNAME". */
     if(det->lang.text != NULL) {
-        RENDER_VERBATIM(r, " class=\"language-");
+        RENDER_VERBATIM(r, " class=\"");
+        if(strncmp(det->lang.text, "language-", 9) != 0) {
+            RENDER_VERBATIM(r, "language-");
+        }
         render_attribute(r, &det->lang, render_html_escaped);
         RENDER_VERBATIM(r, "\"");
     }

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -785,3 +785,19 @@ bar
 bar</p>
 ````````````````````````````````
 
+## [Issue 295](https://github.com/mity/md4c/issues/295)
+
+```````````````````````````````` example
+```language-r
+x <- 1
+```
+
+```r
+x <- 1
+```
+.
+<pre><code class="language-r">x &lt;- 1
+</code></pre>
+<pre><code class="language-r">x &lt;- 1
+</code></pre>
+````````````````````````````````


### PR DESCRIPTION
Avoid repeated language- in info string.
Fix #295
See [commonmark/commonmark.js#277](https://github.com/commonmark/commonmark.js/issues/277).