### PR TITLE
Fix incorrect heading interpretation in math spans

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5267,6 +5267,43 @@ md_is_setext_underline(MD_CTX* ctx, OFF beg, OFF* p_end, unsigned* p_level)
 {
     OFF off = beg + 1;
 
+    /* Check if the LaTeX math extension is enabled and if we are currently inside a paragraph. */
+    if((ctx->parser.flags & MD_FLAG_LATEXMATHSPANS) && ctx->current_block && ctx->current_block->type == MD_BLOCK_P) {
+        MD_LINE* lines = (MD_LINE*)(ctx->current_block + 1);
+        MD_SIZE i;
+        int opened_math = 0;
+
+        /* Iterate through all lines of the current paragraph to see if there's an unclosed math span. */
+        for(i = 0; i < ctx->current_block->n_lines; i++) {
+            OFF off2 = lines[i].beg;
+            while(off2 < lines[i].end) {
+                if(CH(off2) == _T('$')) {
+                    /* Count consecutive '$' characters (1 - inline, 2 - display). */
+                    int n = 0;
+                    while(off2 < lines[i].end && CH(off2) == _T('$')) {
+                        n++;
+                        off2++;
+                    }
+                    if(opened_math == 0) {
+                        /* If no math is open, and we see 1 or 2 '$', mark it as opened. */
+                        opened_math = (n <= 2 ? n : 0);
+                    } else if(opened_math == n) {
+                        /* If a math span is open, and we see a matching number of '$', it is now closed. */
+                        opened_math = 0;
+                    }
+                } else if(CH(off2) == _T('\\')) {
+                    off2 += 2;
+                } else {
+                    off2++;
+                }
+            }
+        }
+        /* If after scanning all lines, the math span is still open,
+         * we prevent the current line from being interpreted as a Setext heading. */
+        if(opened_math != 0)
+            return FALSE;
+    }
+
     while(off < ctx->size  &&  CH(off) == CH(beg))
         off++;
 

--- a/test/spec-latex-math.txt
+++ b/test/spec-latex-math.txt
@@ -68,6 +68,46 @@ $$
 --flatex-math
 ````````````````````````````````
 
+A line consisting of only `=` or `-` within a math span isn't interpreted
+as a Setext underline:
+
+```````````````````````````````` example
+$$
+a
+=
+b
+$$
+.
+<p><x-equation type="display"> a = b </x-equation></p>
+.
+--flatex-math
+````````````````````````````````
+
+```````````````````````````````` example
+$
+a
+-
+b
+$
+.
+<p><x-equation> a - b </x-equation></p>
+.
+--flatex-math
+````````````````````````````````
+
+Escaped dollars don't start a math span:
+
+```````````````````````````````` example
+\$
+Header
+=
+.
+<h1>$
+Header</h1>
+.
+--flatex-math
+````````````````````````````````
+
 Note though that many (simple) renderers may output the math spans just as a
 verbatim text. (This includes the HTML renderer used by the `md2html` utility.)
 


### PR DESCRIPTION
Prevent Setext heading interpretation within LaTeX math spans. Add test cases for such scenarios.

It's common to write LaTeX equations like this:
```
$$
lhs
=
rhs
$$
```
in master `$$ lhs` would be formatted as a heading, which is clearly incorrect.