### PR TITLE
README.md: Add link to md4lean

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ Ports and bindings to other languages:
 * [PyMD4C](https://github.com/dominickpastore/pymd4c):
   Python bindings for MD4C.
 
+* [md4lean](https://github.com/acmepjz/md4lean):
+  [Lean](https://lean-lang.org/) bindings for MD4C.
+
 
 Software using MD4C:
 


### PR DESCRIPTION
I want to advertise md4lean, a Lean binding for md4c. Lean <https://lean-lang.org/> is a functional programming language as well as an interactive theorem prover.