### PR TITLE
Add superscript and subscript span extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ extensions:
   (text enclosed in double pipe marks, e.g. `||hidden text||`). (Note that the
   HTML renderer outputs them in a custom tag `<x-spoiler>`.)
 
+* With the flag `MD_FLAG_SUPERSCRIPTS`, superscript spans are enabled
+  (text enclosed in caret marks, e.g. `x^2^`). The HTML renderer outputs
+  `<sup>`.
+
+* With the flag `MD_FLAG_SUBSCRIPTS`, subscript spans are enabled
+  (text enclosed in single tilde marks, e.g. `H~2~O`). The HTML renderer
+  outputs `<sub>`. When used together with `MD_FLAG_STRIKETHROUGH`, single
+  tilde renders as subscript and double tilde `~~text~~` as strikethrough.
+
 * With the flag `MD_FLAG_PERMISSIVEURLAUTOLINKS` permissive URL autolinks
   (not enclosed in `<` and `>`) are supported.
 

--- a/md2html/md2html.c
+++ b/md2html/md2html.c
@@ -255,6 +255,8 @@ static const CMDLINE_OPTION cmdline_options[] = {
     {  0,  "fpermissive-www-autolinks",     '.', 0 },
     {  0,  "fspoilers",                     'P', 0 },
     {  0,  "fstrikethrough",                'S', 0 },
+    {  0,  "fsuperscripts",                 '^', 0 },
+    {  0,  "fsubscripts",                   '~', 0 },
     {  0,  "ftables",                       'T', 0 },
     {  0,  "ftasklists",                    'X', 0 },
     {  0,  "funderline",                    '_', 0 },
@@ -311,6 +313,8 @@ usage(void)
         "                       Force all soft breaks to act as hard breaks\n"
         "      --fspoilers      Enable spoiler spans (||hidden text||)\n"
         "      --fstrikethrough Enable strike-through spans\n"
+        "      --fsuperscripts  Enable superscript spans (^text^)\n"
+        "      --fsubscripts    Enable subscript spans (~text~)\n"
         "      --ftables        Enable tables\n"
         "      --ftasklists     Enable task lists\n"
         "      --funderline     Enable underline spans\n"
@@ -386,6 +390,8 @@ cmdline_callback(int opt, char const* value, void* data)
         case 'T':   parser_flags |= MD_FLAG_TABLES; break;
         case 'P':   parser_flags |= MD_FLAG_SPOILERS; break;
         case 'S':   parser_flags |= MD_FLAG_STRIKETHROUGH; break;
+        case '^':   parser_flags |= MD_FLAG_SUPERSCRIPTS; break;
+        case '~':   parser_flags |= MD_FLAG_SUBSCRIPTS; break;
         case 'L':   parser_flags |= MD_FLAG_LATEXMATHSPANS; break;
         case 'K':   parser_flags |= MD_FLAG_WIKILINKS; break;
         case 'X':   parser_flags |= MD_FLAG_TASKLISTS; break;

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -467,6 +467,8 @@ enter_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_CODE:              RENDER_VERBATIM(r, "<code>"); break;
         case MD_SPAN_DEL:               RENDER_VERBATIM(r, "<del>"); break;
         case MD_SPAN_SPOILER:           RENDER_VERBATIM(r, "<x-spoiler>"); break;
+        case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "<sup>"); break;
+        case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "<sub>"); break;
         case MD_SPAN_LATEXMATH:         RENDER_VERBATIM(r, "<x-equation>"); break;
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "<x-equation type=\"display\">"); break;
         case MD_SPAN_WIKILINK:          render_open_wikilink_span(r, (MD_SPAN_WIKILINK_DETAIL*) detail); break;
@@ -494,6 +496,8 @@ leave_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_CODE:              RENDER_VERBATIM(r, "</code>"); break;
         case MD_SPAN_DEL:               RENDER_VERBATIM(r, "</del>"); break;
         case MD_SPAN_SPOILER:           RENDER_VERBATIM(r, "</x-spoiler>"); break;
+        case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "</sup>"); break;
+        case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "</sub>"); break;
         case MD_SPAN_LATEXMATH:         /*fall through*/
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "</x-equation>"); break;
         case MD_SPAN_WIKILINK:          RENDER_VERBATIM(r, "</x-wikilink>"); break;

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2600,8 +2600,6 @@ md_opener_stack(MD_CTX* ctx, int mark_index)
 
         case _T('~'):   return (mark->end - mark->beg == 1) ? &TILDE_OPENERS_1 : &TILDE_OPENERS_2;
 
-        case _T('^'):   return &CARET_OPENERS;
-
         case _T('!'):
         case _T('['):   return &BRACKET_OPENERS;
 

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -198,7 +198,7 @@ struct MD_CTX_tag {
 #endif
 
     /* For resolving of inline spans. */
-    MD_MARKSTACK opener_stacks[17];
+    MD_MARKSTACK opener_stacks[18];
 #define ASTERISK_OPENERS_oo_mod3_0      (ctx->opener_stacks[0])     /* Opener-only */
 #define ASTERISK_OPENERS_oo_mod3_1      (ctx->opener_stacks[1])
 #define ASTERISK_OPENERS_oo_mod3_2      (ctx->opener_stacks[2])
@@ -216,6 +216,7 @@ struct MD_CTX_tag {
 #define BRACKET_OPENERS                 (ctx->opener_stacks[14])
 #define DOLLAR_OPENERS                  (ctx->opener_stacks[15])
 #define PIPE_OPENERS                    (ctx->opener_stacks[16])
+#define CARET_OPENERS                   (ctx->opener_stacks[17])
 
     /* Stack of dummies which need to call free() for pointers stored in them.
      * These are constructed during inline parsing and freed after all the block
@@ -2599,6 +2600,8 @@ md_opener_stack(MD_CTX* ctx, int mark_index)
 
         case _T('~'):   return (mark->end - mark->beg == 1) ? &TILDE_OPENERS_1 : &TILDE_OPENERS_2;
 
+        case _T('^'):   return &CARET_OPENERS;
+
         case _T('!'):
         case _T('['):   return &BRACKET_OPENERS;
 
@@ -2737,8 +2740,11 @@ md_build_mark_char_map(MD_CTX* ctx)
     ctx->mark_char_map[']'] = 1;
     ctx->mark_char_map['\0'] = 1;
 
-    if(ctx->parser.flags & MD_FLAG_STRIKETHROUGH)
+    if(ctx->parser.flags & (MD_FLAG_STRIKETHROUGH | MD_FLAG_SUBSCRIPTS))
         ctx->mark_char_map['~'] = 1;
+
+    if(ctx->parser.flags & MD_FLAG_SUPERSCRIPTS)
+        ctx->mark_char_map['^'] = 1;
 
     if(ctx->parser.flags & MD_FLAG_LATEXMATHSPANS)
         ctx->mark_char_map['$'] = 1;
@@ -3299,11 +3305,69 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, int table_m
                 continue;
             }
 
-            /* A potential strikethrough/equation start/end. */
-            if(ch == _T('$') || ch == _T('~')) {
-                OFF tmp = off+1;
+            /* A potential superscript start/end: ^text^ */
+            if(ch == _T('^') && (ctx->parser.flags & MD_FLAG_SUPERSCRIPTS)) {
+                OFF tmp = off + 1;
 
-                while(tmp < line->end && CH(tmp) == ch)
+                while(tmp < line->end && CH(tmp) == _T('^'))
+                    tmp++;
+
+                /* Only a single caret is a superscript delimiter; longer runs are literal. */
+                if(tmp - off == 1) {
+                    unsigned flags = MD_MARK_POTENTIAL_OPENER | MD_MARK_POTENTIAL_CLOSER;
+
+                    /* Cannot open before whitespace; cannot close after whitespace. */
+                    if(off + 1 >= line->end  ||  ISUNICODEWHITESPACE(off + 1))
+                        flags &= ~MD_MARK_POTENTIAL_OPENER;
+                    if(off == line->beg  ||  ISUNICODEWHITESPACEBEFORE(off))
+                        flags &= ~MD_MARK_POTENTIAL_CLOSER;
+                    if(flags != 0)
+                        ADD_MARK(ch, off, off + 1, flags);
+                }
+
+                off = tmp;
+                continue;
+            }
+
+            /* A potential strikethrough/subscript start/end. */
+            if(ch == _T('~')) {
+                OFF tmp = off + 1;
+
+                while(tmp < line->end && CH(tmp) == _T('~'))
+                    tmp++;
+
+                if(tmp - off == 1  &&  (ctx->parser.flags & MD_FLAG_SUBSCRIPTS)) {
+                    /* Subscript: can open after any non-whitespace, cannot open
+                     * before whitespace; cannot close after whitespace. */
+                    unsigned flags = MD_MARK_POTENTIAL_OPENER | MD_MARK_POTENTIAL_CLOSER;
+
+                    if(off + 1 >= line->end  ||  ISUNICODEWHITESPACE(off + 1))
+                        flags &= ~MD_MARK_POTENTIAL_OPENER;
+                    if(off == line->beg  ||  ISUNICODEWHITESPACEBEFORE(off))
+                        flags &= ~MD_MARK_POTENTIAL_CLOSER;
+                    if(flags != 0)
+                        ADD_MARK(ch, off, off + 1, flags);
+                } else if(tmp - off <= 2  &&  (ctx->parser.flags & MD_FLAG_STRIKETHROUGH)) {
+                    /* Strikethrough: standard GFM left/right-flanking rules. */
+                    unsigned flags = MD_MARK_POTENTIAL_OPENER | MD_MARK_POTENTIAL_CLOSER;
+
+                    if(off > line->beg  &&  !ISUNICODEWHITESPACEBEFORE(off)  &&  !ISUNICODEPUNCTBEFORE(off))
+                        flags &= ~MD_MARK_POTENTIAL_OPENER;
+                    if(tmp < line->end  &&  !ISUNICODEWHITESPACE(tmp)  &&  !ISUNICODEPUNCT(tmp))
+                        flags &= ~MD_MARK_POTENTIAL_CLOSER;
+                    if(flags != 0)
+                        ADD_MARK(ch, off, tmp, flags);
+                }
+
+                off = tmp;
+                continue;
+            }
+
+            /* A potential equation start/end. */
+            if(ch == _T('$')) {
+                OFF tmp = off + 1;
+
+                while(tmp < line->end && CH(tmp) == _T('$'))
                     tmp++;
 
                 if(tmp - off <= 2) {
@@ -3823,6 +3887,23 @@ md_analyze_tilde(MD_CTX* ctx, int mark_index)
 }
 
 static void
+md_analyze_caret(MD_CTX* ctx, int mark_index)
+{
+    MD_MARK* mark = &ctx->marks[mark_index];
+
+    if((mark->flags & MD_MARK_POTENTIAL_CLOSER)  &&  CARET_OPENERS.top >= 0) {
+        int opener_index = CARET_OPENERS.top;
+
+        md_pop_openers(ctx, opener_index);
+        md_resolve_range(ctx, opener_index, mark_index);
+        return;
+    }
+
+    if(mark->flags & MD_MARK_POTENTIAL_OPENER)
+        md_mark_stack_push(ctx, &CARET_OPENERS, mark_index);
+}
+
+static void
 md_analyze_dollar(MD_CTX* ctx, int mark_index)
 {
     MD_MARK* mark = &ctx->marks[mark_index];
@@ -4073,7 +4154,7 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
         /* Skip resolved spans. */
         if(mark->flags & MD_MARK_RESOLVED) {
             if((mark->flags & MD_MARK_OPENER)  &&
-               !((flags & MD_ANALYZE_NOSKIP_EMPH) && ISANYOF_(mark->ch, "*_~")))
+               !((flags & MD_ANALYZE_NOSKIP_EMPH) && ISANYOF_(mark->ch, "*_~^")))
             {
                 MD_ASSERT(i < mark->next);
                 i = mark->next + 1;
@@ -4104,6 +4185,7 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
             case '_':   /* Pass through. */
             case '*':   md_analyze_emph(ctx, i); break;
             case '~':   md_analyze_tilde(ctx, i); break;
+            case '^':   md_analyze_caret(ctx, i); break;
             case '$':   md_analyze_dollar(ctx, i); break;
             case '.':   /* Pass through. */
             case ':':   /* Pass through. */
@@ -4168,7 +4250,7 @@ md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
     int i;
 
     md_analyze_marks(ctx, lines, n_lines, mark_beg, mark_end, _T("&"), 0);
-    md_analyze_marks(ctx, lines, n_lines, mark_beg, mark_end, _T("*_~$"), 0);
+    md_analyze_marks(ctx, lines, n_lines, mark_beg, mark_end, _T("*_~$^"), 0);
 
     if(ctx->parser.flags & MD_FLAG_SPOILERS) {
         for(i = mark_beg; i < mark_end; i++) {
@@ -4337,10 +4419,24 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
                     break;
 
                 case '~':
+                    if(mark->end - mark->beg == 1  &&  (ctx->parser.flags & MD_FLAG_SUBSCRIPTS)) {
+                        if(mark->flags & MD_MARK_OPENER)
+                            MD_ENTER_SPAN(MD_SPAN_SUBSCRIPT, NULL);
+                        else
+                            MD_LEAVE_SPAN(MD_SPAN_SUBSCRIPT, NULL);
+                    } else {
+                        if(mark->flags & MD_MARK_OPENER)
+                            MD_ENTER_SPAN(MD_SPAN_DEL, NULL);
+                        else
+                            MD_LEAVE_SPAN(MD_SPAN_DEL, NULL);
+                    }
+                    break;
+
+                case '^':
                     if(mark->flags & MD_MARK_OPENER)
-                        MD_ENTER_SPAN(MD_SPAN_DEL, NULL);
+                        MD_ENTER_SPAN(MD_SPAN_SUPERSCRIPT, NULL);
                     else
-                        MD_LEAVE_SPAN(MD_SPAN_DEL, NULL);
+                        MD_LEAVE_SPAN(MD_SPAN_SUPERSCRIPT, NULL);
                     break;
 
                 case '|':

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -150,7 +150,17 @@ typedef enum MD_SPANTYPE {
     /* Spoiler (hidden content revealed on interaction).
      * Syntax: ||hidden text||
      * Note: Recognized only when MD_FLAG_SPOILERS is enabled. */
-    MD_SPAN_SPOILER
+    MD_SPAN_SPOILER,
+
+    /* <sup>...</sup>
+     * Syntax: ^superscript^
+     * Note: Recognized only when MD_FLAG_SUPERSCRIPTS is enabled. */
+    MD_SPAN_SUPERSCRIPT,
+
+    /* <sub>...</sub>
+     * Syntax: ~subscript~
+     * Note: Recognized only when MD_FLAG_SUBSCRIPTS is enabled. */
+    MD_SPAN_SUBSCRIPT
 } MD_SPANTYPE;
 
 /* Text is the actual textual contents of span. */
@@ -324,6 +334,8 @@ typedef struct MD_SPAN_WIKILINK {
 #define MD_FLAG_UNDERLINE                   0x4000  /* Enable underline extension (and disables '_' for normal emphasis). */
 #define MD_FLAG_HARD_SOFT_BREAKS            0x8000  /* Force all soft breaks to act as hard breaks. */
 #define MD_FLAG_SPOILERS                    0x10000 /* Enable ||hidden text|| spoiler spans. */
+#define MD_FLAG_SUPERSCRIPTS                0x20000 /* Enable ^superscript^ spans. */
+#define MD_FLAG_SUBSCRIPTS                  0x40000 /* Enable ~subscript~ spans. */
 
 #define MD_FLAG_PERMISSIVEAUTOLINKS         (MD_FLAG_PERMISSIVEEMAILAUTOLINKS | MD_FLAG_PERMISSIVEURLAUTOLINKS | MD_FLAG_PERMISSIVEWWWAUTOLINKS)
 #define MD_FLAG_NOHTML                      (MD_FLAG_NOHTMLBLOCKS | MD_FLAG_NOHTMLSPANS)

--- a/test/spec-subscripts.txt
+++ b/test/spec-subscripts.txt
@@ -62,6 +62,26 @@ H~ 2~O
 --fsubscripts
 ````````````````````````````````
 
+A tilde cannot close a subscript span when immediately preceded by whitespace:
+
+```````````````````````````````` example
+H~2 ~O
+.
+<p>H~2 ~O</p>
+.
+--fsubscripts
+````````````````````````````````
+
+A tilde at the start of a line can open but not close a span:
+
+```````````````````````````````` example
+~2~
+.
+<p><sub>2</sub></p>
+.
+--fsubscripts
+````````````````````````````````
+
 
 ## Code spans suppress markers
 

--- a/test/spec-subscripts.txt
+++ b/test/spec-subscripts.txt
@@ -1,0 +1,126 @@
+
+# Subscript Spans
+
+With the flag `MD_FLAG_SUBSCRIPTS`, MD4C enables recognition of inline
+subscript spans using the `~text~` syntax (single tilde on each side).  The
+HTML renderer outputs these as `<sub>`.
+
+
+## Basic recognition
+
+```````````````````````````````` example
+H~2~O
+.
+<p>H<sub>2</sub>O</p>
+.
+--fsubscripts
+````````````````````````````````
+
+Subscripts may open after regular text characters:
+
+```````````````````````````````` example
+log~2~x
+.
+<p>log<sub>2</sub>x</p>
+.
+--fsubscripts
+````````````````````````````````
+
+Subscripts may appear inside link text:
+
+```````````````````````````````` example
+[H~2~O](http://example.com)
+.
+<p><a href="http://example.com">H<sub>2</sub>O</a></p>
+.
+--fsubscripts
+````````````````````````````````
+
+
+## Opt-in behavior
+
+Without `MD_FLAG_SUBSCRIPTS` the `~text~` sequence is treated as literal text:
+
+```````````````````````````````` example
+H~2~O
+.
+<p>H~2~O</p>
+.
+
+````````````````````````````````
+
+
+## Whitespace rules
+
+A tilde cannot open a subscript span when immediately followed by whitespace:
+
+```````````````````````````````` example
+H~ 2~O
+.
+<p>H~ 2~O</p>
+.
+--fsubscripts
+````````````````````````````````
+
+
+## Code spans suppress markers
+
+Tilde characters inside code spans are treated as literal text:
+
+```````````````````````````````` example
+`H~2~O`
+.
+<p><code>H~2~O</code></p>
+.
+--fsubscripts
+````````````````````````````````
+
+
+## Double tilde is not subscript
+
+Double tilde `~~text~~` is not a subscript delimiter; it is only meaningful
+when `MD_FLAG_STRIKETHROUGH` is also enabled:
+
+```````````````````````````````` example
+~~old~~
+.
+<p>~~old~~</p>
+.
+--fsubscripts
+````````````````````````````````
+
+
+## Interaction with `MD_FLAG_STRIKETHROUGH`
+
+With only `MD_FLAG_STRIKETHROUGH`, single-tilde `~text~` renders as
+strikethrough (GFM compatibility):
+
+```````````````````````````````` example
+~text~
+.
+<p><del>text</del></p>
+.
+--fstrikethrough
+````````````````````````````````
+
+With only `MD_FLAG_STRIKETHROUGH`, double-tilde `~~text~~` also renders as
+strikethrough:
+
+```````````````````````````````` example
+~~text~~
+.
+<p><del>text</del></p>
+.
+--fstrikethrough
+````````````````````````````````
+
+With both `MD_FLAG_SUBSCRIPTS` and `MD_FLAG_STRIKETHROUGH`, single tilde
+becomes subscript and double tilde remains strikethrough:
+
+```````````````````````````````` example
+H~2~O and ~~old~~
+.
+<p>H<sub>2</sub>O and <del>old</del></p>
+.
+--fsubscripts --fstrikethrough
+````````````````````````````````

--- a/test/spec-superscripts.txt
+++ b/test/spec-superscripts.txt
@@ -1,0 +1,175 @@
+
+# Superscript Spans
+
+With the flag `MD_FLAG_SUPERSCRIPTS`, MD4C enables recognition of inline
+superscript spans using the `^text^` syntax.  A single caret on each side
+wraps the content, which the HTML renderer outputs as `<sup>`.
+
+
+## Basic recognition
+
+```````````````````````````````` example
+x^2^
+.
+<p>x<sup>2</sup></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+Superscripts may open after regular text characters:
+
+```````````````````````````````` example
+foo^bar^
+.
+<p>foo<sup>bar</sup></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+Superscripts may appear inside emphasis:
+
+```````````````````````````````` example
+_x^2^_
+.
+<p><em>x<sup>2</sup></em></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+Superscripts may appear inside strong emphasis:
+
+```````````````````````````````` example
+**x^2^**
+.
+<p><strong>x<sup>2</sup></strong></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Opt-in behavior
+
+Without `MD_FLAG_SUPERSCRIPTS` the `^` sequence is treated as literal text:
+
+```````````````````````````````` example
+x^2^
+.
+<p>x^2^</p>
+.
+
+````````````````````````````````
+
+
+## Whitespace rules
+
+A caret cannot open a superscript span when immediately followed by whitespace:
+
+```````````````````````````````` example
+x^ 2^
+.
+<p>x^ 2^</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+A caret cannot close a superscript span when immediately preceded by whitespace:
+
+```````````````````````````````` example
+x^2 ^
+.
+<p>x^2 ^</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Longer caret runs are literal
+
+Double or longer caret runs are not split into superscript delimiters:
+
+```````````````````````````````` example
+x^^y^^
+.
+<p>x^^y^^</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Paragraph boundary stops resolution
+
+A superscript span cannot cross a paragraph boundary:
+
+```````````````````````````````` example
+x^
+
+2^
+.
+<p>x^</p>
+<p>2^</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Code spans suppress markers
+
+Caret characters inside code spans are treated as literal text:
+
+```````````````````````````````` example
+`x^2^`
+.
+<p><code>x^2^</code></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Unmatched delimiters are literal
+
+An opening caret with no matching closer is literal:
+
+```````````````````````````````` example
+x^2
+.
+<p>x^2</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+A closing caret with no matching opener is literal:
+
+```````````````````````````````` example
+x2^
+.
+<p>x2^</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
+## Interaction with other extensions
+
+### Subscripts (requires `MD_FLAG_SUBSCRIPTS`)
+
+Superscript and subscript may nest inside each other:
+
+```````````````````````````````` example
+x^a~b~^
+.
+<p>x<sup>a<sub>b</sub></sup></p>
+.
+--fsuperscripts --fsubscripts
+````````````````````````````````
+
+### Spoilers (requires `MD_FLAG_SPOILERS`)
+
+Superscript may appear inside a spoiler span:
+
+```````````````````````````````` example
+||x^2^||
+.
+<p><x-spoiler>x<sup>2</sup></x-spoiler></p>
+.
+--fsuperscripts --fspoilers
+````````````````````````````````

--- a/test/spec-superscripts.txt
+++ b/test/spec-superscripts.txt
@@ -125,6 +125,29 @@ Caret characters inside code spans are treated as literal text:
 ````````````````````````````````
 
 
+A caret at the very start of a line can still open a superscript span (exercises
+the `off == line->beg` branch for the closer check):
+
+```````````````````````````````` example
+^2^
+.
+<p><sup>2</sup></p>
+.
+--fsuperscripts
+````````````````````````````````
+
+A lone caret at the start of a line followed by whitespace can be neither opener
+nor closer, so it is treated as literal text:
+
+```````````````````````````````` example
+^ x
+.
+<p>^ x</p>
+.
+--fsuperscripts
+````````````````````````````````
+
+
 ## Unmatched delimiters are literal
 
 An opening caret with no matching closer is literal:


### PR DESCRIPTION
## Summary

This PR adds two opt-in inline span extensions to MD4C.

The new syntaxes are:

```
x^2^    (superscript)
H~2~O   (subscript)
```

When `MD_FLAG_SUPERSCRIPTS` is enabled, MD4C emits a new `MD_SPAN_SUPERSCRIPT`
span. When `MD_FLAG_SUBSCRIPTS` is enabled, MD4C emits a new `MD_SPAN_SUBSCRIPT`
span. The bundled HTML renderer outputs them as:

```html
x<sup>2</sup>
H<sub>2</sub>O
```

`md2html` gets two new options: `--fsuperscripts` and `--fsubscripts`.

When `MD_FLAG_SUBSCRIPTS` and `MD_FLAG_STRIKETHROUGH` are both active, `~text~`
renders as subscript and `~~text~~` remains strikethrough, preserving GFM
compatibility.

A 600-second OSS-Fuzz run found no crashes or assertion failures.

These extensions will be used in [react-native-enriched-markdown](https://github.com/software-mansion-labs/react-native-enriched-markdown). 