### PR TITLE
Fix O(n²) performance regression in spoiler span analysis

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4173,8 +4173,15 @@ md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
     if(ctx->parser.flags & MD_FLAG_SPOILERS) {
         for(i = mark_beg; i < mark_end; i++) {
             MD_MARK* mark = &ctx->marks[i];
-            if(mark->flags & MD_MARK_RESOLVED)
+            if(mark->flags & MD_MARK_RESOLVED) {
+                /* Skip resolved link/image spans. Their contents were already
+                 * analyzed by the recursive md_analyze_link_contents() call
+                 * inside md_resolve_links(). Without this, deeply nested
+                 * brackets cause O(n^2) parsing time. */
+                if((mark->flags & MD_MARK_OPENER)  &&  ISANYOF_(mark->ch, "[!"))
+                    i = mark->next;
                 continue;
+            }
             if(mark->ch == '|' && mark->end - mark->beg == 2)
                 md_analyze_pipe(ctx, i);
         }

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4178,7 +4178,7 @@ md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
                  * analyzed by the recursive md_analyze_link_contents() call
                  * inside md_resolve_links(). Without this, deeply nested
                  * brackets cause O(n^2) parsing time. */
-                if((mark->flags & MD_MARK_OPENER)  &&  ISANYOF_(mark->ch, "[!"))
+                if((mark->flags & MD_MARK_OPENER)  &&  (mark->ch == '[' || mark->ch == '!'))
                     i = mark->next;
                 continue;
             }

--- a/test/spec-spoilers.txt
+++ b/test/spec-spoilers.txt
@@ -398,7 +398,7 @@ A spoiler inside the display portion of a wiki link:
 --fspoilers --fwiki-links
 ````````````````````````````````
 
-Links and images inside spoiler spans are recognized normally:
+Links, images, and inline spans inside spoiler spans are recognized normally:
 
 ```````````````````````````````` example
 ||[link](http://example.com) inside spoiler||
@@ -412,6 +412,14 @@ Links and images inside spoiler spans are recognized normally:
 ||![img](http://example.com/img.png) inside spoiler||
 .
 <p><x-spoiler><img src="http://example.com/img.png" alt="img"> inside spoiler</x-spoiler></p>
+.
+--fspoilers
+````````````````````````````````
+
+```````````````````````````````` example
+||*em* inside spoiler||
+.
+<p><x-spoiler><em>em</em> inside spoiler</x-spoiler></p>
 .
 --fspoilers
 ````````````````````````````````

--- a/test/spec-spoilers.txt
+++ b/test/spec-spoilers.txt
@@ -398,6 +398,24 @@ A spoiler inside the display portion of a wiki link:
 --fspoilers --fwiki-links
 ````````````````````````````````
 
+Links and images inside spoiler spans are recognized normally:
+
+```````````````````````````````` example
+||[link](http://example.com) inside spoiler||
+.
+<p><x-spoiler><a href="http://example.com">link</a> inside spoiler</x-spoiler></p>
+.
+--fspoilers
+````````````````````````````````
+
+```````````````````````````````` example
+||![img](http://example.com/img.png) inside spoiler||
+.
+<p><x-spoiler><img src="http://example.com/img.png" alt="img"> inside spoiler</x-spoiler></p>
+.
+--fspoilers
+````````````````````````````````
+
 Wiki links with a `|` separator must not be mistaken for spoiler delimiters:
 
 ```````````````````````````````` example


### PR DESCRIPTION
`md_analyze_link_contents()` is called recursively for every resolved link
pair. Each call runs the spoiler loop over its mark range, but unlike
`md_analyze_marks()`, the loop had no skip optimization for resolved spans
— it walked through every inner mark one by one.

With 64,135 resolved links in the OSS-Fuzz testcase, this caused
4.86 billion loop iterations instead of 268,499 — O(n²) behavior.

**Fix:** when the loop hits a resolved `[` or `!` opener, jump to
`mark->next` directly, mirroring what `md_analyze_marks()` already does

Fixes: #311 