### PR TITLE
Small Changes

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -576,4 +576,3 @@ md_html(const MD_CHAR* input, MD_SIZE input_size,
 
     return md_parse(input, input_size, &parser, (void*) &render);
 }
-

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -23,13 +23,13 @@
  * IN THE SOFTWARE.
  */
 
-#include "md4c.h"
-
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "md4c.h"
 
 
 /*****************************
@@ -979,6 +979,7 @@ struct MD_UNICODE_FOLD_INFO_tag {
     static inline unsigned
     md_decode_unicode(const CHAR* str, OFF off, SZ str_size, SZ* p_size)
     {
+		MD_UNUSED(str_size);
         *p_size = 1;
         return (unsigned) str[off];
     }
@@ -2532,7 +2533,7 @@ struct MD_MARK_tag {
             OFF beg;
             OFF end;
         };
-        void* pointer; // Dummy marks can sometimes store a pointer
+        void* pointer; /* Dummy marks can sometimes store a pointer */
     };
 
     /* For unresolved openers, 'next' may be used to form a stack of

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -979,7 +979,7 @@ struct MD_UNICODE_FOLD_INFO_tag {
     static inline unsigned
     md_decode_unicode(const CHAR* str, OFF off, SZ str_size, SZ* p_size)
     {
-		MD_UNUSED(str_size);
+        MD_UNUSED(str_size);
         *p_size = 1;
         return (unsigned) str[off];
     }


### PR DESCRIPTION
Move local header to after system/libc headers
Suppress unused parameter warning
Change C++ style comment to ISO C90 style comment
Delete extra LF at the end of md4c-html.c