### PR TITLE
Refactor the permissive autolink extension code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ New Features:
 
     Contributed by [Gregory Moskaliuk](https://github.com/hryhoriiK97).
 
+Changes:
+
+  * Permissive autolinks (`MD_FLAG_PERMISSIVExxxAUTOLINKS` flags) have been
+    improved and some links with non-alphanumeric characters are now recognized.
+
+    However please note this will always be a subject of painful search for
+    reasonable trade-off between recognizing more obscure URLs versus opening
+    gates to potential false positives.
+
+    We generally recommend to use standard autolinks as defined by
+    [CommonMark specification](https://spec.commonmark.org/0.31.2/#autolinks)
+    (i.e. enclosed between `<` and `>`), especially for links containing more
+    obscure combinations of non-alphanumeric characters.
+
 
 ## Version 0.5.3
 

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -3998,139 +3998,163 @@ md_scan_right_for_resolved_mark(MD_CTX* ctx, MD_MARK* mark_from, OFF off, MD_MAR
     return NULL;
 }
 
+static int
+md_analyze_permissive_autolink_segment(MD_CTX* ctx, OFF off, OFF end, OFF* p_end,
+            int scan_backwards, MD_CHAR component_delim, const MD_CHAR* word_extra,
+            const MD_CHAR* word_delims, MD_MARK** p_cursor)
+{
+    int n_components = 0;
+    int n_open_brackets = 0;
+    int seen_word_delim = TRUE;
+    int seen_component_delim = TRUE;
+    OFF component_beg = off;
+
+    if(word_extra == NULL)
+        word_extra = _T("");
+    if(word_delims == NULL)
+        word_delims = _T("");
+
+    while(off != end) {
+        if(scan_backwards)
+            off--;
+
+        /* Only accept extra and delimiter characters if they're not part of a
+         * resolved mark. */
+        if(!ISALNUM(off)  &&  !ISWHITESPACE(off)) {
+            if((!scan_backwards && md_scan_right_for_resolved_mark(ctx, *p_cursor, off, p_cursor) != NULL)  ||
+               (scan_backwards && md_scan_left_for_resolved_mark(ctx, *p_cursor, off, p_cursor) != NULL)) {
+                if(scan_backwards)
+                    off++;
+                break;
+            }
+        }
+
+        /* The autolink can be _inside_ brackets so we disallow unbalanced bracket pairs in the URL.
+         * (Note the brackets are not allowed in e-mail username, so we happily skip this in that case.) */
+        if(!scan_backwards) {
+            if(CH(off) == _T('(')) {
+                n_open_brackets++;
+            } else if(CH(off) == _T(')')) {
+                if(n_open_brackets <= 0)
+                    break;
+                n_open_brackets--;
+            }
+        }
+
+        if(ISALNUM(off)  ||  ISANYOF(off, word_extra)) {
+            seen_word_delim = FALSE;
+            seen_component_delim = FALSE;
+        } else {
+            if(seen_word_delim)
+                break;
+
+            if(ISANYOF(off, word_delims)) {
+                seen_word_delim = TRUE;
+            } else if(component_delim != _T('\0')  &&  CH(off) == component_delim) {
+                if(seen_component_delim)
+                    break;
+                seen_component_delim = TRUE;
+                component_beg = off;
+                n_components++;
+            } else {
+                if(scan_backwards)
+                    off++;
+                break;
+            }
+        }
+
+        if(!scan_backwards)
+            off++;
+    }
+
+    /* Rollback falsely consumed delimiter. */
+    if(seen_word_delim || seen_component_delim)
+        off = (scan_backwards ? off+1 : off-1);
+
+    if(off != component_beg)
+        n_components++;
+
+    if(n_open_brackets != 0)
+        return -1;
+
+    *p_end = off;
+    return n_components;
+}
+
 static void
 md_analyze_permissive_autolink(MD_CTX* ctx, int mark_index)
 {
-    static const struct {
-        const MD_CHAR start_char;
-        const MD_CHAR delim_char;
-        const MD_CHAR* allowed_nonalnum_chars_inside;
-        const MD_CHAR* allowed_nonalnum_chars_anywhere;
-        int min_components;
-        const MD_CHAR optional_end_char;
-    } URL_MAP[] = {
-        { _T('\0'), _T('.'),  _T(".-_"),      _T(""),   2, _T('\0') },    /* host, mandatory */
-        { _T('/'),  _T('/'),  _T("/._"),      _T("+-"), 0, _T('/') },     /* path */
-        { _T('?'),  _T('&'),  _T("&.-+_=()"), _T(""),   1, _T('\0') },    /* query */
-        { _T('#'),  _T('\0'), _T(".-+_") ,    _T(""),   1, _T('\0') }     /* fragment */
-    };
-
     MD_MARK* opener = &ctx->marks[mark_index];
     MD_MARK* closer = &ctx->marks[mark_index + 1];  /* The dummy. */
-    OFF line_beg = closer->beg;     /* md_collect_mark() set this for us */
+    OFF line_beg = closer->beg;     /* md_collect_mark() sets this for us */
     OFF line_end = closer->end;     /* ditto */
     OFF beg = opener->beg;
     OFF end = opener->end;
     MD_MARK* left_cursor = opener;
-    int left_boundary_ok = FALSE;
     MD_MARK* right_cursor = opener;
-    int right_boundary_ok = FALSE;
-    unsigned i;
 
     MD_ASSERT(closer->ch == 'D');
 
+    /* E-mail requires the user name (before '@', i.e. scanning backwards). */
     if(opener->ch == '@') {
         MD_ASSERT(CH(opener->beg) == _T('@'));
-
-        /* Scan backwards for the user name (before '@'). */
-        while(beg > line_beg) {
-            if(ISALNUM(beg-1))
-                beg--;
-            else if(beg >= line_beg+2  &&  ISALNUM(beg-2)  &&
-                        ISANYOF(beg-1, _T(".-_+"))  &&
-                        md_scan_left_for_resolved_mark(ctx, left_cursor, beg-1, &left_cursor) == NULL  &&
-                        ISALNUM(beg))
-                beg--;
-            else
-                break;
-        }
-        if(beg == opener->beg)      /* empty user name */
+        if(md_analyze_permissive_autolink_segment(ctx, beg, line_beg, &beg, TRUE,
+                _T('\0'), NULL, _T(".-_+"), &left_cursor) < 1)
             return;
     }
 
     /* Verify there's line boundary, whitespace, allowed punctuation or
      * resolved opener mark just before the suspected autolink. */
-    if(beg == line_beg  ||  ISUNICODEWHITESPACEBEFORE(beg)  ||  ISANYOF(beg-1, _T("({["))) {
-        left_boundary_ok = TRUE;
-    } else {
-        MD_MARK* left_mark;
+    if(beg > line_beg  &&  !ISUNICODEWHITESPACEBEFORE(beg)  &&  !ISANYOF(beg-1, _T("({["))) {
+        MD_MARK* mark;
 
-        left_mark = md_scan_left_for_resolved_mark(ctx, left_cursor, beg-1, &left_cursor);
-        if(left_mark != NULL  &&  (left_mark->flags & MD_MARK_OPENER))
-            left_boundary_ok = TRUE;
+        mark = md_scan_left_for_resolved_mark(ctx, left_cursor, beg-1, &left_cursor);
+        if(mark == NULL  ||  !(mark->flags & MD_MARK_OPENER))
+            return;
     }
-    if(!left_boundary_ok)
+
+    /* Scan for hostname segment. Hostname is mandatory and requires at least two
+     * components delimited with a dot. */
+    if(md_analyze_permissive_autolink_segment(ctx, end, line_end, &end, FALSE,
+            _T('.'), NULL, _T("-_"), &right_cursor) < 2)
         return;
 
-    for(i = 0; i < SIZEOF_ARRAY(URL_MAP); i++) {
-        int n_components = 0;
-        int n_open_brackets = 0;
-        int component_len = 0;
+    if(opener->ch != '@') {
+        /* Scan for path segment. */
+        if(end < line_end  &&  CH(end) == _T('/')) {
+            if(md_analyze_permissive_autolink_segment(ctx, end+1, line_end, &end, FALSE,
+                        _T('/'), _T(".+-_"), NULL, &right_cursor) < 0)
+                return;
 
-        if(URL_MAP[i].start_char != _T('\0')) {
-            if(end >= line_end  ||  CH(end) != URL_MAP[i].start_char)
-                continue;
-            if(URL_MAP[i].min_components > 0  &&  (end+1 >= line_end  ||  !ISALNUM(end+1)))
-                continue;
-            end++;
+            /* Path can also end with additional '/' if its a directory. */
+            if(end < line_end  &&  CH(end) == _T('/'))
+                end++;
         }
 
-        while(end < line_end) {
-            if(ISALNUM(end)  ||  ISANYOF(end, URL_MAP[i].allowed_nonalnum_chars_anywhere)) {
-                if(n_components == 0)
-                    n_components++;
-                component_len++;
-                end++;
-            } else if(component_len > 0  &&  CH(end) == URL_MAP[i].delim_char  &&  end+1 < line_end  &&
-                      (ISALNUM(end+1)  ||  ISANYOF(end+1, URL_MAP[i].allowed_nonalnum_chars_anywhere))) {
-                n_components++;
-                component_len = 0;
-                end++;
-            } else if(ISANYOF(end, URL_MAP[i].allowed_nonalnum_chars_inside)  &&
-                      md_scan_right_for_resolved_mark(ctx, right_cursor, end, &right_cursor) == NULL  &&
-                      ((end > line_beg && (ISALNUM(end-1) || CH(end-1) == _T(')')))  ||  CH(end) == _T('('))  &&
-                      ((end+1 < line_end && (ISALNUM(end+1) || CH(end+1) == _T('(')))  ||  CH(end) == _T(')')))
-            {
-                /* brackets have to be balanced. */
-                if(CH(end) == _T('(')) {
-                    n_open_brackets++;
-                } else if(CH(end) == _T(')')) {
-                    if(n_open_brackets <= 0)
-                        break;
-                    n_open_brackets--;
-                }
-
-                component_len++;
-                end++;
-            } else {
-                break;
-            }
+        /* Scan for query segment. */
+        if(end < line_end  &&  CH(end) == _T('?')) {
+            if(md_analyze_permissive_autolink_segment(ctx, end+1, line_end, &end, FALSE,
+                        _T('&'), _T("._=()"), _T("+-"), &right_cursor) < 0)
+                return;
         }
 
-        if(end < line_end  &&  URL_MAP[i].optional_end_char != _T('\0')  &&
-                CH(end) == URL_MAP[i].optional_end_char)
-            end++;
-
-        if(n_components < URL_MAP[i].min_components  ||  n_open_brackets != 0)
-            return;
-
-        if(opener->ch == '@')   /* E-mail autolinks wants only the host. */
-            break;
+        /* Scan for fragment segment. */
+        if(end < line_end  &&  CH(end) == _T('#')) {
+            if(md_analyze_permissive_autolink_segment(ctx, end+1, line_end, &end, FALSE,
+                        _T('\0'), NULL, _T(".-+_"), &right_cursor) < 0)
+                return;
+        }
     }
 
     /* Verify there's line boundary, whitespace, allowed punctuation or
      * resolved closer mark just after the suspected autolink. */
-    if(end == line_end  ||  ISUNICODEWHITESPACE(end)  ||  ISANYOF(end, _T(")}].!?,;"))) {
-        right_boundary_ok = TRUE;
-    } else {
-        MD_MARK* right_mark;
+    if(end < line_end  &&  !ISUNICODEWHITESPACE(end)  &&  !ISANYOF(end, _T(")}].!?,;"))) {
+        MD_MARK* mark;
 
-        right_mark = md_scan_right_for_resolved_mark(ctx, right_cursor, end, &right_cursor);
-        if(right_mark != NULL  &&  (right_mark->flags & MD_MARK_CLOSER))
-            right_boundary_ok = TRUE;
+        mark = md_scan_right_for_resolved_mark(ctx, right_cursor, end, &right_cursor);
+        if(mark == NULL  ||  !(mark->flags & MD_MARK_CLOSER))
+            return;
     }
-    if(!right_boundary_ok)
-        return;
 
     /* Success, we are an autolink. */
     opener->beg = beg;

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -796,6 +796,14 @@ https://codereview.qt-project.org/c/qt/qtwayland/+/545836
 --fpermissive-autolinks
 ````````````````````````````````
 
+```````````````````````````````` example
+https://www.youtube.com/watch?v=_tEL8bJ7yqU
+.
+<p><a href="https://www.youtube.com/watch?v=_tEL8bJ7yqU">https://www.youtube.com/watch?v=_tEL8bJ7yqU</a></p>
+.
+--fpermissive-autolinks
+````````````````````````````````
+
 
 ## [Issue 271](https://github.com/mity/md4c/issues/271)
 


### PR DESCRIPTION
 * Change the main scanning logic so that we don't repeat "is this char a word character" condition in multiple code branches, as it has incrementally diverted from simple alnum() check to a very complex question involving checking different characters for each URL segment, and even whether some of them are not actually part of a resolved mark.

 * Isolate the code shared by the URL segments (username, hostname, path, query and fragment) into new md_analyze_permissive_autolink_segment().

 * That function is able to scan backwards, so it can be reused when scanning for e-mail username (before the '@') instead of (poorly) duplicated code.

 * Having the shared code in a new function, we also get rid of the baroque URL_MAP[] structure.