### PR TITLE
Fix double-free in md_build_attr_append_substr on second realloc failure

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -1450,16 +1450,15 @@ md_build_attr_append_substr(MD_CTX* ctx, MD_ATTRIBUTE_BUILD* build,
             MD_LOG("realloc() failed.");
             return -1;
         }
+        build->substr_types = new_substr_types;
+
         /* Note +1 to reserve space for final offset (== raw_size). */
         new_substr_offsets = (OFF*) realloc(build->substr_offsets,
                                     (build->substr_alloc+1) * sizeof(OFF));
         if(new_substr_offsets == NULL) {
             MD_LOG("realloc() failed.");
-            free(new_substr_types);
             return -1;
         }
-
-        build->substr_types = new_substr_types;
         build->substr_offsets = new_substr_offsets;
     }
 


### PR DESCRIPTION
If realloc(substr_types) succeeds and moves the allocation, then realloc(substr_offsets) fails, the old substr_types pointer has already been freed by realloc internally. The error path did not update build->substr_types before returning, so md_free_attribute would later call free() on the dangling old pointer -- a double-free.

to fix we do: build->substr_types = new_substr_types immediately after the first realloc succeeds. The second failure path then needs no explicit free() since md_free_attribute already handles cleanup correctly.