### PR TITLE
Fix: Four parser/renderer correctness and OOM bugs.

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -194,7 +194,8 @@ render_utf8_codepoint(MD_HTML* r, unsigned codepoint,
         utf8[3] = 0x80 + ((codepoint >>  0) & 0x3f);
     }
 
-    if(0 < codepoint  &&  codepoint <= 0x10ffff)
+    if(0 < codepoint  &&  codepoint <= 0x10ffff
+            &&  (codepoint < 0xd800 || codepoint > 0xdfff))
         fn_append(r, (char*)utf8, (MD_SIZE)n);
     else
         fn_append(r, utf8_replacement_char, 3);

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -1440,12 +1440,12 @@ md_build_attr_append_substr(MD_CTX* ctx, MD_ATTRIBUTE_BUILD* build,
     if(build->substr_count >= build->substr_alloc) {
         MD_TEXTTYPE* new_substr_types;
         OFF* new_substr_offsets;
-
-        build->substr_alloc = (build->substr_alloc > 0
+        int new_alloc = (build->substr_alloc > 0
                 ? build->substr_alloc + build->substr_alloc / 2
                 : 8);
+
         new_substr_types = (MD_TEXTTYPE*) realloc(build->substr_types,
-                                    build->substr_alloc * sizeof(MD_TEXTTYPE));
+                                    new_alloc * sizeof(MD_TEXTTYPE));
         if(new_substr_types == NULL) {
             MD_LOG("realloc() failed.");
             return -1;
@@ -1454,12 +1454,13 @@ md_build_attr_append_substr(MD_CTX* ctx, MD_ATTRIBUTE_BUILD* build,
 
         /* Note +1 to reserve space for final offset (== raw_size). */
         new_substr_offsets = (OFF*) realloc(build->substr_offsets,
-                                    (build->substr_alloc+1) * sizeof(OFF));
+                                    (new_alloc+1) * sizeof(OFF));
         if(new_substr_offsets == NULL) {
             MD_LOG("realloc() failed.");
             return -1;
         }
         build->substr_offsets = new_substr_offsets;
+        build->substr_alloc = new_alloc;
     }
 
     build->substr_types[build->substr_count] = type;
@@ -2136,7 +2137,7 @@ md_is_link_title(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg,
         OFF line_end = lines[line_index].end;
 
         while(off < line_end) {
-            if(CH(off) == _T('\\')  &&  off+1 < ctx->size  &&  (ISPUNCT(off+1) || ISNEWLINE(off+1))) {
+            if(CH(off) == _T('\\')  &&  off+1 < line_end  &&  ISPUNCT(off+1)) {
                 off++;
             } else if(CH(off) == closer_char) {
                 /* Success. */
@@ -2237,17 +2238,18 @@ md_is_link_reference_definition(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lin
     /* So, it _is_ a reference definition. Remember it. */
     if(ctx->n_ref_defs >= ctx->alloc_ref_defs) {
         MD_REF_DEF* new_defs;
-
-        ctx->alloc_ref_defs = (ctx->alloc_ref_defs > 0
+        int new_alloc = (ctx->alloc_ref_defs > 0
                 ? ctx->alloc_ref_defs + ctx->alloc_ref_defs / 2
                 : 16);
-        new_defs = (MD_REF_DEF*) realloc(ctx->ref_defs, ctx->alloc_ref_defs * sizeof(MD_REF_DEF));
+
+        new_defs = (MD_REF_DEF*) realloc(ctx->ref_defs, new_alloc * sizeof(MD_REF_DEF));
         if(new_defs == NULL) {
             MD_LOG("realloc() failed.");
             goto abort;
         }
 
         ctx->ref_defs = new_defs;
+        ctx->alloc_ref_defs = new_alloc;
     }
     def = &ctx->ref_defs[ctx->n_ref_defs];
     memset(def, 0, sizeof(MD_REF_DEF));

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2137,7 +2137,7 @@ md_is_link_title(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, OFF beg,
         OFF line_end = lines[line_index].end;
 
         while(off < line_end) {
-            if(CH(off) == _T('\\')  &&  off+1 < line_end  &&  ISPUNCT(off+1)) {
+            if(CH(off) == _T('\\')  &&  off+1 < ctx->size  &&  (ISPUNCT(off+1) || ISNEWLINE(off+1))) {
                 off++;
             } else if(CH(off) == closer_char) {
                 /* Success. */

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -1450,16 +1450,15 @@ md_build_attr_append_substr(MD_CTX* ctx, MD_ATTRIBUTE_BUILD* build,
             MD_LOG("realloc() failed.");
             return -1;
         }
+        build->substr_types = new_substr_types;
+
         /* Note +1 to reserve space for final offset (== raw_size). */
         new_substr_offsets = (OFF*) realloc(build->substr_offsets,
                                     (build->substr_alloc+1) * sizeof(OFF));
         if(new_substr_offsets == NULL) {
             MD_LOG("realloc() failed.");
-            free(new_substr_types);
             return -1;
         }
-
-        build->substr_types = new_substr_types;
         build->substr_offsets = new_substr_offsets;
     }
 

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -877,3 +877,15 @@ foo</p>
 .
 --fadmonitions
 ````````````````````````````````
+
+
+## Numeric entity for surrogate code point
+
+Surrogate code points (U+D800..U+DFFF) are not valid Unicode scalar values
+and must be replaced with U+FFFD, like U+0000.
+
+```````````````````````````````` example
+&#xD800; &#xDFFF; &#55296; &#57343;
+.
+<p>� � � �</p>
+````````````````````````````````

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -889,3 +889,22 @@ and must be replaced with U+FFFD, like U+0000.
 .
 <p>� � � �</p>
 ````````````````````````````````
+
+
+## Backslash + newline as soft line break inside a link title
+
+Per CommonMark, a backslash before a line ending is a recognized escape that
+produces a soft line break. This must work inside link titles too -- the
+HTML renderer doesn't distinguish soft breaks from regular newlines, but a
+custom renderer would, so the parser must treat `\\` + newline as an escape
+rather than a literal backslash followed by content.
+
+```````````````````````````````` example
+[foo]: /url "ti\
+tle"
+
+[foo]
+.
+<p><a href="/url" title="ti
+tle">foo</a></p>
+````````````````````````````````


### PR DESCRIPTION
Four small independent correctness fixes — full rationale in the commit message.

- `md_build_attr_append_substr` / `md_is_link_reference_definition` :  commit alloc counters only after realloc succeeds (companion to #324).
- `render_utf8_codepoint` :  reject surrogate codepoints (U+D800..U+DFFF).
- `md_is_link_title` :  `\` + newline is not an escape per CommonMark.

Independent of #324 . Full test suite (916 spec + 29 pathological) passes. Happy to split if needed.