### PR TITLE
Footnotes: Fix assert when a reference appears inside a wiki-link destination.

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2941,7 +2941,7 @@ md_disable_marks(MD_CTX* ctx, int mark_index0, int mark_index1)
 
     for(i = mark_index0; i < mark_index1; i++) {
         ctx->marks[i].ch = 'D';
-        ctx->marks[i].flags &= ~MD_MARK_RESOLVED;
+        ctx->marks[i].flags = 0;
     }
 }
 
@@ -3812,7 +3812,7 @@ md_resolve_links(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 
                 if(delim != NULL) {
                     if(delim->end < closer->beg) {
-                        md_disable_marks(ctx, delim_index+1, delim_index);
+                        md_disable_marks(ctx, opener_index+1, delim_index);
                         delim->flags |= MD_MARK_RESOLVED;
                         opener->end = delim->beg;
                     } else {
@@ -4834,10 +4834,13 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 
                     /* Footnote reference: self-contained span, no text emitted.
                      * Only the opener is ever processed here; the closer mark
-                     * is guaranteed to be skipped by the off-advance below. */
-                    if(opener->flags & MD_MARK_FOOTNOTE_REF) {
+                     * is skipped by the off-advance below. If another resolved
+                     * mark (e.g. a wiki-link '|' delimiter) is emitted first,
+                     * we may reach the closer before the opener. */
+                    if((opener->flags & MD_MARK_FOOTNOTE_REF)  &&  opener->ch == _T('[')  &&
+                       mark->ch != _T(']'))
+                    {
                         MD_MARK* index_mark = (MD_MARK*) opener + 1;
-                        MD_ASSERT(mark->ch != ']');
                         MD_ASSERT(index_mark->ch == 'D');
                         MD_CHECK(md_enter_leave_span_footnote_ref(ctx,
                                       (unsigned int) index_mark->beg,

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2940,8 +2940,19 @@ md_disable_marks(MD_CTX* ctx, int mark_index0, int mark_index1)
     int i;
 
     for(i = mark_index0; i < mark_index1; i++) {
-        ctx->marks[i].ch = 'D';
-        ctx->marks[i].flags = 0;
+        MD_MARK* mark = &ctx->marks[i];
+
+        /* A footnote ref closer may fall outside the disabled range (e.g. when
+         * it is disabled as part of a wiki-link destination). */
+        if(mark->ch == _T('[')  &&  (mark->flags & MD_MARK_FOOTNOTE_REF)  &&
+           mark->next >= 0  &&  mark->next >= mark_index1)
+        {
+            ctx->marks[mark->next].ch = 'D';
+            ctx->marks[mark->next].flags = 0;
+        }
+
+        mark->ch = 'D';
+        mark->flags = 0;
     }
 }
 
@@ -4834,13 +4845,10 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
 
                     /* Footnote reference: self-contained span, no text emitted.
                      * Only the opener is ever processed here; the closer mark
-                     * is skipped by the off-advance below. If another resolved
-                     * mark (e.g. a wiki-link '|' delimiter) is emitted first,
-                     * we may reach the closer before the opener. */
-                    if((opener->flags & MD_MARK_FOOTNOTE_REF)  &&  opener->ch == _T('[')  &&
-                       mark->ch != _T(']'))
-                    {
+                     * is guaranteed to be skipped by the off-advance below. */
+                    if(opener->flags & MD_MARK_FOOTNOTE_REF) {
                         MD_MARK* index_mark = (MD_MARK*) opener + 1;
+                        MD_ASSERT(mark->ch != ']');
                         MD_ASSERT(index_mark->ch == 'D');
                         MD_CHECK(md_enter_leave_span_footnote_ref(ctx,
                                       (unsigned int) index_mark->beg,

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -26,6 +26,19 @@ Raw HTML block:
 --ffootnotes
 ````````````````````````````````
 
+
+## Footnote reference inside wiki-link destination
+
+```````````````````````````````` example
+[[[^|]]]
+[^|]:
+.
+<p><x-wikilink data-target="[^">]</x-wikilink>
+[^|]:</p>
+.
+--ffootnotes --fwiki-links
+````````````````````````````````
+
 Inline:
 
 ```````````````````````````````` example

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -39,6 +39,24 @@ Raw HTML block:
 --ffootnotes --fwiki-links
 ````````````````````````````````
 
+
+```````````````````````````````` example
+x[^1] [[foo|bar]]
+
+[^1]: Note.
+.
+<p>x<sup><a href="#fn-1" id="fnref-1-1">1</a></sup> <x-wikilink data-target="foo">bar</x-wikilink></p>
+<section class="footnotes">
+<ol>
+<li id="fn-1">
+Note.<a href="#fnref-1-1" class="footnote-backref">&#8617;</a>
+</li>
+</ol>
+</section>
+.
+--ffootnotes --fwiki-links
+````````````````````````````````
+
 Inline:
 
 ```````````````````````````````` example


### PR DESCRIPTION
Fixes an assert when --ffootnotes and --fwiki-links are both on and a [^label] ref appears inside a [[dest|label]] destination (e.g. [[[^|]]]).

md_disable_marks() used an empty range, so footnote marks in the destination stayed active and rendering could hit the ] closer before the opener. The fix uses the correct range, clears disabled marks, and disables the footnote’s paired ] when it sits past the |.