### PR TITLE
md_process_leaf_block: Fix sparse table detection.

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5416,7 +5416,7 @@ md_process_leaf_block(MD_CTX* ctx, MD_BLOCK* block)
             SZ table_input_size = n_rows;
             unsigned i;
 
-            for(i = 0; i < n_cols; i++)
+            for(i = 0; i < n_rows; i++)
                 table_input_size += lines[i].end - lines[i].beg;
 
             if(table_input_size / n_cols < n_rows / 4) {


### PR DESCRIPTION
We have used by mistake n_cols instead of n_rows as a limit when iterating over table the rows of the table.

Fixes #351.