### PR TITLE
Add highlight span extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 New Features:
 
+  * Add highlight span extension, enabled with the flag `MD_FLAG_HIGHLIGHT`.
+
+    Syntax example:
+    ```
+    ==highlighted text==
+    ```
+
+    The HTML renderer outputs `<mark>`.
+
+    Contributed by [Gregory Moskaliuk](https://github.com/hryhoriiK97).
+
   * Add GFM-like footnote extension, enabled with the flag `MD_FLAG_FOOTNOTES`.
 
     Syntax example:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ extensions:
   outputs `<sub>`. When used together with `MD_FLAG_STRIKETHROUGH`, single
   tilde renders as subscript and double tilde `~~text~~` as strikethrough.
 
+* With the flag `MD_FLAG_HIGHLIGHT`, highlight spans are enabled
+  (text enclosed in double equals marks, e.g. `==important==`). The HTML
+  renderer outputs `<mark>`.
+
 * With the flag `MD_FLAG_PERMISSIVEURLAUTOLINKS` permissive URL autolinks
   (not enclosed in `<` and `>`) are supported.
 

--- a/md2html/md2html.c
+++ b/md2html/md2html.c
@@ -253,6 +253,7 @@ static const CMDLINE_OPTION cmdline_options[] = {
 
     {  0,  "fadmonitions",                  'D', 0 },
     {  0,  "fcollapse-whitespace",          'W', 0 },
+    {  0,  "fhighlight",                    'M', 0 },
     {  0,  "flatex-math",                   'L', 0 },
     {  0,  "fpermissive-atx-headers",       'A', 0 },
     {  0,  "fpermissive-autolinks",         'V', 0 },
@@ -322,6 +323,7 @@ usage(void)
         "                       --fpermissive-email-autolinks\n"
         "      --fhard-soft-breaks\n"
         "                       Force all soft breaks to act as hard breaks\n"
+        "      --fhighlight    Enable highlight spans (==text==)\n"
         "      --fspoilers      Enable spoiler spans (||hidden text||)\n"
         "      --fstrikethrough Enable strike-through spans\n"
         "      --fsuperscripts  Enable superscript spans (^text^)\n"
@@ -390,6 +392,7 @@ cmdline_callback(int opt, char const* value, void* data)
 
         case 'D':   parser_flags |= MD_FLAG_ADMONITIONS; break;
         case 'E':   renderer_flags |= MD_HTML_FLAG_VERBATIM_ENTITIES; break;
+        case 'M':   parser_flags |= MD_FLAG_HIGHLIGHT; break;
         case 'A':   parser_flags |= MD_FLAG_PERMISSIVEATXHEADERS; break;
         case 'I':   parser_flags |= MD_FLAG_NOINDENTEDCODEBLOCKS; break;
         case 'F':   parser_flags |= MD_FLAG_NOHTMLBLOCKS; break;

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -523,6 +523,7 @@ enter_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_SPOILER:           RENDER_VERBATIM(r, "<x-spoiler>"); break;
         case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "<sup>"); break;
         case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "<sub>"); break;
+        case MD_SPAN_MARK:              RENDER_VERBATIM(r, "<mark>"); break;
         case MD_SPAN_LATEXMATH:         RENDER_VERBATIM(r, "<x-equation>"); break;
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "<x-equation type=\"display\">"); break;
         case MD_SPAN_WIKILINK:          render_open_wikilink_span(r, (MD_SPAN_WIKILINK_DETAIL*) detail); break;
@@ -553,6 +554,7 @@ leave_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_SPOILER:           RENDER_VERBATIM(r, "</x-spoiler>"); break;
         case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "</sup>"); break;
         case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "</sub>"); break;
+        case MD_SPAN_MARK:              RENDER_VERBATIM(r, "</mark>"); break;
         case MD_SPAN_LATEXMATH:         /*fall through*/
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "</x-equation>"); break;
         case MD_SPAN_WIKILINK:          RENDER_VERBATIM(r, "</x-wikilink>"); break;

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -222,7 +222,7 @@ struct MD_CTX_tag {
 #endif
 
     /* For resolving of inline spans. */
-    MD_MARKSTACK opener_stacks[18];
+    MD_MARKSTACK opener_stacks[19];
 #define ASTERISK_OPENERS_oo_mod3_0      (ctx->opener_stacks[0])     /* Opener-only */
 #define ASTERISK_OPENERS_oo_mod3_1      (ctx->opener_stacks[1])
 #define ASTERISK_OPENERS_oo_mod3_2      (ctx->opener_stacks[2])
@@ -241,6 +241,7 @@ struct MD_CTX_tag {
 #define DOLLAR_OPENERS                  (ctx->opener_stacks[15])
 #define PIPE_OPENERS                    (ctx->opener_stacks[16])
 #define CARET_OPENERS                   (ctx->opener_stacks[17])
+#define EQUAL_OPENERS                   (ctx->opener_stacks[18])
 
     /* Stack of dummies which need to call free() for pointers stored in them.
      * These are constructed during inline parsing and freed after all the block
@@ -2733,6 +2734,7 @@ md_free_ref_defs(MD_CTX* ctx)
  *  ';': Maybe end of entity.
  *  '<': Maybe start of raw HTML or autolink.
  *  '>': Maybe end of raw HTML or autolink.
+ *  '=': Maybe highlight start/end (needs MD_FLAG_HIGHLIGHT).
  *  '[': Maybe start of link label or link text.
  *  '!': Equivalent of '[' for image.
  *  ']': Maybe end of link label or link text.
@@ -2974,6 +2976,9 @@ md_build_mark_char_map(MD_CTX* ctx)
 
     if(ctx->parser.flags & MD_FLAG_LATEXMATHSPANS)
         ctx->mark_char_map['$'] = 1;
+
+    if(ctx->parser.flags & MD_FLAG_HIGHLIGHT)
+        ctx->mark_char_map['='] = 1;
 
     if(ctx->parser.flags & MD_FLAG_PERMISSIVEEMAILAUTOLINKS)
         ctx->mark_char_map['@'] = 1;
@@ -3554,6 +3559,30 @@ md_collect_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines, int table_m
                         flags &= ~MD_MARK_POTENTIAL_CLOSER;
                     if(flags != 0)
                         ADD_MARK(ch, off, off + 1, flags);
+                }
+
+                off = tmp;
+                continue;
+            }
+
+            /* A potential highlight start/end: ==text== */
+            if(ch == _T('=') && (ctx->parser.flags & MD_FLAG_HIGHLIGHT)) {
+                OFF tmp = off + 1;
+
+                while(tmp < line->end && CH(tmp) == _T('='))
+                    tmp++;
+
+                /* Only exactly two equals signs form a highlight delimiter. */
+                if(tmp - off == 2) {
+                    unsigned flags = MD_MARK_POTENTIAL_OPENER | MD_MARK_POTENTIAL_CLOSER;
+
+                    /* Cannot open before whitespace; cannot close after whitespace. */
+                    if(tmp >= line->end  ||  ISUNICODEWHITESPACE(tmp))
+                        flags &= ~MD_MARK_POTENTIAL_OPENER;
+                    if(off == line->beg  ||  ISUNICODEWHITESPACEBEFORE(off))
+                        flags &= ~MD_MARK_POTENTIAL_CLOSER;
+                    if(flags != 0)
+                        ADD_MARK(ch, off, tmp, flags);
                 }
 
                 off = tmp;
@@ -4276,6 +4305,27 @@ md_analyze_spoiler(MD_CTX* ctx, int mark_index)
         md_mark_stack_push(ctx, &PIPE_OPENERS, mark_index);
 }
 
+static void
+md_analyze_highlight(MD_CTX* ctx, int mark_index)
+{
+    MD_MARK* mark = &ctx->marks[mark_index];
+
+    /* Only "==" is recognized as a highlight mark. */
+    if(mark->end - mark->beg != 2)
+        return;
+
+    if((mark->flags & MD_MARK_POTENTIAL_CLOSER)  &&  EQUAL_OPENERS.top >= 0) {
+        int opener_index = EQUAL_OPENERS.top;
+
+        md_pop_openers(ctx, opener_index);
+        md_resolve_range(ctx, opener_index, mark_index);
+        return;
+    }
+
+    if(mark->flags & MD_MARK_POTENTIAL_OPENER)
+        md_mark_stack_push(ctx, &EQUAL_OPENERS, mark_index);
+}
+
 static MD_MARK*
 md_scan_left_for_resolved_mark(MD_CTX* ctx, MD_MARK* mark_from, OFF off, MD_MARK** p_cursor)
 {
@@ -4542,6 +4592,7 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
             case ':':   /* Pass through. */
             case '@':   md_analyze_permissive_autolink(ctx, i); break;
             case '|':   md_analyze_spoiler(ctx, i); break;
+            case '=':   md_analyze_highlight(ctx, i); break;
         }
 
         if(mark->flags & MD_MARK_RESOLVED) {
@@ -4608,6 +4659,8 @@ md_analyze_link_contents(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
     emph_mark_types[n_emph_mark_types++] = _T('_');
     if(ctx->parser.flags & MD_FLAG_LATEXMATHSPANS)
         emph_mark_types[n_emph_mark_types++] = _T('$');
+    if(ctx->parser.flags & MD_FLAG_HIGHLIGHT)
+        emph_mark_types[n_emph_mark_types++] = _T('=');
     if(ctx->parser.flags & MD_FLAG_SPOILERS)
         emph_mark_types[n_emph_mark_types++] = _T('|');
     if(ctx->parser.flags & MD_FLAG_SUPERSCRIPTS)
@@ -4832,6 +4885,15 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
                             MD_ENTER_SPAN(MD_SPAN_SPOILER, NULL);
                         else
                             MD_LEAVE_SPAN(MD_SPAN_SPOILER, NULL);
+                    }
+                    break;
+
+                case '=':
+                    if(mark->end - mark->beg == 2) {
+                        if(mark->flags & MD_MARK_OPENER)
+                            MD_ENTER_SPAN(MD_SPAN_MARK, NULL);
+                        else
+                            MD_LEAVE_SPAN(MD_SPAN_MARK, NULL);
                     }
                     break;
 

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -186,7 +186,12 @@ typedef enum MD_SPANTYPE {
      * Note: Recognized only when MD_FLAG_FOOTNOTES is enabled.
      * The span is self-contained: no MD_TEXT callbacks fire between enter and
      * leave. All needed information is in MD_SPAN_FOOTNOTE_REF_DETAIL. */
-    MD_SPAN_FOOTNOTE_REF
+    MD_SPAN_FOOTNOTE_REF,
+
+    /* <mark>...</mark>
+     * Syntax: ==highlight==
+     * Note: Recognized only when MD_FLAG_HIGHLIGHT is enabled. */
+    MD_SPAN_MARK
 } MD_SPANTYPE;
 
 /* Text is the actual textual contents of span. */
@@ -383,6 +388,7 @@ typedef struct MD_BLOCK_FOOTNOTE_DEF_DETAIL {
 #define MD_FLAG_SUBSCRIPTS                  0x40000 /* Enable ~subscript~ spans. */
 #define MD_FLAG_ADMONITIONS                 0x80000 /* Enable admonitions extension. */
 #define MD_FLAG_FOOTNOTES                   0x100000 /* Enable [^label] footnote references. */
+#define MD_FLAG_HIGHLIGHT                   0x200000 /* Enable ==highlight== spans. */
 
 #define MD_FLAG_PERMISSIVEAUTOLINKS         (MD_FLAG_PERMISSIVEEMAILAUTOLINKS | MD_FLAG_PERMISSIVEURLAUTOLINKS | MD_FLAG_PERMISSIVEWWWAUTOLINKS)
 #define MD_FLAG_NOHTML                      (MD_FLAG_NOHTMLBLOCKS | MD_FLAG_NOHTMLSPANS)

--- a/test/spec-highlight.txt
+++ b/test/spec-highlight.txt
@@ -1,0 +1,257 @@
+
+# Highlight Spans
+
+With the flag `MD_FLAG_HIGHLIGHT`, MD4C enables recognition of inline
+highlight spans using the `==text==` syntax. A pair of equals signs on each
+side wraps the content, which the HTML renderer outputs as `<mark>`.
+
+
+## Basic recognition
+
+```````````````````````````````` example
+==Hello, world!==
+.
+<p><mark>Hello, world!</mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+Highlight spans may appear inline alongside normal text:
+
+```````````````````````````````` example
+This is ==very important== text.
+.
+<p>This is <mark>very important</mark> text.</p>
+.
+--fhighlight
+````````````````````````````````
+
+Multiple independent highlight spans may appear in the same paragraph:
+
+```````````````````````````````` example
+==first== and ==second==
+.
+<p><mark>first</mark> and <mark>second</mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Flag required
+
+Without `MD_FLAG_HIGHLIGHT` the `==` sequence is treated as literal text:
+
+```````````````````````````````` example
+==highlight==
+.
+<p>==highlight==</p>
+.
+````````````````````````````````
+
+
+## Nested inline spans
+
+Emphasis inside a highlight span:
+
+```````````````````````````````` example
+==very *important* text==
+.
+<p><mark>very <em>important</em> text</mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+Strong emphasis inside a highlight span:
+
+```````````````````````````````` example
+==**bold** and _italic_==
+.
+<p><mark><strong>bold</strong> and <em>italic</em></mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+Inline code inside a highlight span:
+
+```````````````````````````````` example
+==highlighted `code`==
+.
+<p><mark>highlighted <code>code</code></mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+A link inside a highlight span:
+
+```````````````````````````````` example
+==highlighted [link](http://example.com)==
+.
+<p><mark>highlighted <a href="http://example.com">link</a></mark></p>
+.
+--fhighlight
+````````````````````````````````
+
+A highlight span inside a link:
+
+```````````````````````````````` example
+[==highlighted link==](http://example.com)
+.
+<p><a href="http://example.com"><mark>highlighted link</mark></a></p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Whitespace rules
+
+An equals delimiter cannot open a highlight span when immediately followed by
+whitespace:
+
+```````````````````````````````` example
+== highlight==
+.
+<p>== highlight==</p>
+.
+--fhighlight
+````````````````````````````````
+
+An equals delimiter cannot close a highlight span when immediately preceded by
+whitespace:
+
+```````````````````````````````` example
+==highlight ==
+.
+<p>==highlight ==</p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Delimiter length
+
+Single equals signs are not highlight delimiters:
+
+```````````````````````````````` example
+=highlight=
+.
+<p>=highlight=</p>
+.
+--fhighlight
+````````````````````````````````
+
+Longer equals runs are not split into highlight delimiters:
+
+```````````````````````````````` example
+===highlight===
+.
+<p>===highlight===</p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Unmatched delimiters
+
+An opening delimiter with no matching closer is literal:
+
+```````````````````````````````` example
+==highlight
+.
+<p>==highlight</p>
+.
+--fhighlight
+````````````````````````````````
+
+A closing delimiter with no matching opener is literal:
+
+```````````````````````````````` example
+highlight==
+.
+<p>highlight==</p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Paragraph boundary stops resolution
+
+A highlight span cannot cross a paragraph boundary:
+
+```````````````````````````````` example
+This ==has a
+
+new paragraph==.
+.
+<p>This ==has a</p>
+<p>new paragraph==.</p>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Suppression inside code
+
+Equals signs inside code spans are treated as literal text:
+
+```````````````````````````````` example
+`==code==`
+.
+<p><code>==code==</code></p>
+.
+--fhighlight
+````````````````````````````````
+
+Equals signs inside fenced code blocks are treated as literal text:
+
+```````````````````````````````` example
+```
+==code==
+```
+.
+<pre><code>==code==
+</code></pre>
+.
+--fhighlight
+````````````````````````````````
+
+
+## Interaction with other extensions
+
+Highlight may appear inside a spoiler span:
+
+```````````````````````````````` example
+||==highlighted spoiler==||
+.
+<p><x-spoiler><mark>highlighted spoiler</mark></x-spoiler></p>
+.
+--fhighlight --fspoilers
+````````````````````````````````
+
+Highlight may appear inside strikethrough:
+
+```````````````````````````````` example
+~~==highlighted deletion==~~
+.
+<p><del><mark>highlighted deletion</mark></del></p>
+.
+--fhighlight --fstrikethrough
+````````````````````````````````
+
+Highlight may appear inside table cells:
+
+```````````````````````````````` example
+| Feature | Status |
+| --- | --- |
+| Highlight | ==done== |
+.
+<table>
+<thead>
+<tr><th>Feature</th><th>Status</th></tr>
+</thead>
+<tbody>
+<tr><td>Highlight</td><td><mark>done</mark></td></tr>
+</tbody>
+</table>
+.
+--fhighlight --ftables
+````````````````````````````````


### PR DESCRIPTION
## Summary

Adds an opt-in highlight span extension for [`==highlight==` syntax](https://www.markdownguide.org/extended-syntax/#highlight).

This introduces `MD_FLAG_HIGHLIGHT` and `MD_SPAN_MARK`, renders highlights as semantic HTML `<mark>...</mark>`, and exposes the feature through `md2html --fhighlight`.