### PR TITLE
Add Apostrophe to HTML escaping

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -104,10 +104,11 @@ render_html_escaped(MD_HTML* r, const MD_CHAR* data, MD_SIZE size)
 
         if(off < size) {
             switch(data[off]) {
+                case '"':   RENDER_VERBATIM(r, "&quot;"); break;
                 case '&':   RENDER_VERBATIM(r, "&amp;"); break;
+                case '\'':  RENDER_VERBATIM(r, "&#x27;"); break;
                 case '<':   RENDER_VERBATIM(r, "&lt;"); break;
                 case '>':   RENDER_VERBATIM(r, "&gt;"); break;
-                case '"':   RENDER_VERBATIM(r, "&quot;"); break;
             }
             off++;
         } else {
@@ -614,7 +615,7 @@ md_html(const MD_CHAR* input, MD_SIZE input_size,
     for(i = 0; i < 256; i++) {
         unsigned char ch = (unsigned char) i;
 
-        if(strchr("\"&<>", ch) != NULL)
+        if(strchr("\"&'<>", ch) != NULL)
             render.escape_map[i] |= NEED_HTML_ESC_FLAG;
 
         if(!ISALNUM(ch)  &&  strchr("~-_.+!*(),%#@?=;:/$", ch) == NULL)


### PR DESCRIPTION
Apostrophe is HTML escaped, because it is used in XHTML
`&apos;` can be used instead of `&#x27;`
`&#x27;` is the OWASP recommendation because HTML4 and IE8 doesn't support `&apos;`
XHTML, HTML5, & IE11 support `&apos;`

[OWASP Recommendation for HTML escaping](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-rules-summary)