### PR TITLE
Accept percent sign in auto links

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4502,7 +4502,7 @@ md_analyze_permissive_autolink(MD_CTX* ctx, int mark_index)
         /* Scan for path segment. */
         if(end < line_end  &&  CH(end) == _T('/')) {
             if(md_analyze_permissive_autolink_segment(ctx, end+1, line_end, &end, FALSE,
-                        _T('/'), _T(".+-_~"), NULL, &right_cursor) < 0)
+                        _T('/'), _T(".+-_~%"), NULL, &right_cursor) < 0)
                 return;
 
             /* Path can also end with additional '/' if its a directory. */


### PR DESCRIPTION
Without this patch, bare URIs (without `<...>` or `[...]`) that contain percent signs aren't turned into links. Test case:

```
md2html$ cat test.md
https://github.com

https://github.com/LoopZ/TheList/blob/fa803c25/source/Interrupt%20List/INT%2021%20DOS%20Function%20Calls/INT%20215F08%20DOS%205%20DISABLE%20DRIVE.txt
md2html$ ./md2html --github test.md
<p><a href="https://github.com">https://github.com</a></p>
<p><a href="https://github.com/LoopZ/TheList/blob/fa803c25/source/Interrupt%20List/INT%2021%20DOS%20Function%20Calls/INT%20215F08%20DOS%205%20DISABLE%20DRIVE.txt">https://github.com/LoopZ/TheList/blob/fa803c25/source/Interrupt%20List/INT%2021%20DOS%20Function%20Calls/INT%20215F08%20DOS%205%20DISABLE%20DRIVE.txt</a></p>
md2html$
```

This is the successful output in which both links are recognised. Without this patch the longer link isn't recognised.