### PR TITLE
md_parse: reject input large enough to overflow internal int counters

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -7198,6 +7198,12 @@ md_parse(const MD_CHAR* text, MD_SIZE size, const MD_PARSER* parser, void* userd
         return -1;
     }
 
+    if(size > (MD_SIZE)(INT_MAX / 16)) {
+        if(parser->debug_log != NULL)
+            parser->debug_log("Input too large.", userdata);
+        return -1;
+    }
+
     /* Setup context structure. */
     memset(&ctx, 0, sizeof(MD_CTX));
     ctx.text = text;


### PR DESCRIPTION
`ctx->n_block_bytes` and `ctx->n_marks` are `int` and grow with input size. For an input large enough to push them past `INT_MAX`, the grow-checks (`n_block_bytes + n_bytes > alloc_block_bytes`, `n_marks >= alloc_marks`) overflow to a negative value, the realloc is skipped, and the next write lands past the allocation.

Reaching this needs a multi-GB document on 64-bit (or a 32-bit `size_t` build), so it is hardening rather than a practically reachable bug, but the signed counters make it real. Reject inputs whose size could get there. `INT_MAX / 16` sits well above the worst-case growth (`n_block_bytes` rises by at most `sizeof(MD_BLOCK) + sizeof(MD_VERBATIMLINE)` per source line) and far above any realistic document.
