### PR TITLE
md_analyze_table_alignment: bound the dash scan by the row end

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5125,7 +5125,7 @@ md_analyze_table_alignment(MD_CTX* ctx, OFF beg, OFF end, MD_ALIGN* align, int n
     while(n_align > 0) {
         int index = 0;  /* index into align_map[] */
 
-        while(CH(off) != _T('-'))
+        while(off < end  &&  CH(off) != _T('-'))
             off++;
         if(off > beg  &&  CH(off-1) == _T(':'))
             index |= 1;


### PR DESCRIPTION
The first inner loop in `md_analyze_table_alignment` scans for `-` with no bound on `off`, unlike the sibling loop directly below it which already checks `off < end`. It is safe today only because `n_align` equals the number of dash runs in the underline row, so a `-` is always found before `end`. That invariant is easy to break with a future change, and the asymmetry with the adjacent loop is its own smell. Add the missing `off < end` guard.
