### PR TITLE
md_html: escape raw HTML in image alt attribute

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -577,7 +577,16 @@ text_callback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdat
                                         : " "));
                                 break;
         case MD_TEXT_SOFTBR:    RENDER_VERBATIM(r, (r->image_nesting_level == 0 ? "\n" : " ")); break;
-        case MD_TEXT_HTML:      render_verbatim(r, text, size); break;
+        case MD_TEXT_HTML:      /* When inside a Markdown image label, the text falls into
+                                 * the alt="..." attribute opened by render_open_img_span().
+                                 * Raw HTML must be escaped there, exactly like normal text,
+                                 * otherwise it breaks out of the attribute. Compare the
+                                 * image_nesting_level handling in enter_span_callback(). */
+                                if(r->image_nesting_level == 0)
+                                    render_verbatim(r, text, size);
+                                else
+                                    render_html_escaped(r, text, size);
+                                break;
         case MD_TEXT_ENTITY:    render_entity(r, text, size, render_html_escaped); break;
         default:                render_html_escaped(r, text, size); break;
     }

--- a/test/regressions.txt
+++ b/test/regressions.txt
@@ -1027,3 +1027,16 @@ http://example.com>
 <p>&lt;
 http://example.com&gt;</p>
 ````````````````````````````````
+
+
+## Raw HTML in an image label must not break out of the alt attribute
+
+The image label is rendered into the `alt="..."` attribute, so any raw
+HTML span in it has to be escaped like normal text instead of being
+emitted verbatim.
+
+```````````````````````````````` example
+![<x title=" y" onerror="alert(1)">](/url)
+.
+<p><img src="/url" alt="&lt;x title=&quot; y&quot; onerror=&quot;alert(1)&quot;&gt;"></p>
+````````````````````````````````


### PR DESCRIPTION
The HTML renderer opens the `alt="..."` attribute in `render_open_img_span()` and renders the image label into it. `enter_span_callback()` already suppresses nested span tags while `image_nesting_level > 0`, but `text_callback()` still emitted `MD_TEXT_HTML` verbatim, so a raw HTML span in an image label broke out of the attribute:

```
![<x title=" y" onerror="alert(1)">](/url)
```

rendered as:

```
<p><img src="/url" alt="<x title=" y" onerror="alert(1)">"></p>
```

where `onerror` becomes a live attribute on the generated `img`.

This routes `MD_TEXT_HTML` through `render_html_escaped()` when inside an image label, matching the renderer's documented intent (only plain text falls into `alt`), the `MD_FLAG_NOHTML` output, and cmark-gfm, which escapes raw HTML in the same plain-text context. Behaviour outside image labels is unchanged. Adds a regression test.
