### PR TITLE
scripts: capture pathological-tests.py return code

### DIFF
--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
             "pathological-tests.py",
             "-p", str(program)
     ]
-    subprocess.run(args)
+    p = subprocess.run(args)
     if p.returncode != 0:
         err_count += 1
 


### PR DESCRIPTION
`run-tests.py` stores each spec suite's `CompletedProcess` in `p` and checks `p.returncode`, but the `pathological-tests.py` invocation was not assigned to `p`. The next check re-tested the last spec suite's return code, so when the spec suites passed but the pathological tests failed, `err_count` stayed unchanged and the runner exited 0, hiding the regression from CI (the `ci-build` workflow runs this runner on push and PR).

One-line fix: assign the pathological run to `p` so its return code is checked.
