### PR TITLE
Code spans: keep the line-break space when a line ends in whitespace

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5069,8 +5069,13 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines)
                 if(off > tmp)
                     MD_TEXT(text_type, STR(tmp), off-tmp);
 
-                /* and new lines are transformed into single spaces. */
-                if(off == line->end)
+                /* and new lines are transformed into single spaces. Emit the
+                 * space when off rests on an interior newline still preceding
+                 * the closer. Testing off == line->end here instead drops the
+                 * space when the line ends in whitespace, because the loop
+                 * above advances off past line->end over the trailing blanks
+                 * (CommonMark code-span examples 335, 337, 640). */
+                if(off < mark->beg  &&  ISNEWLINE(off))
                     MD_TEXT(text_type, _T(" "), 1);
             } else if(text_type == MD_TEXT_HTML) {
                 /* Inside raw HTML, we output the new line verbatim, including


### PR DESCRIPTION
## Problem

Inside a code span, when an interior line ends in one or more spaces, the rendered span comes out one space short.

CommonMark §6.3 converts interior line endings to a single space and preserves interior content, including the trailing spaces before the line ending. A line ending `bar  ` followed by `baz` should render `bar   baz` (two trailing spaces plus the line-ending space), not `bar  baz`.

Three CommonMark 0.31 spec examples are affected: 335, 337, and 640.

## Root cause

In `md_process_inlines`, the code-span line-break handler emits the line's trailing whitespace, then emits the newline-as-space only `if(off == line->end)`. The trailing-whitespace loop just above advances `off` past `line->end` whenever the line ends in blanks, so in exactly that case the guard is false and the space is dropped.

## Fix

Emit the space when `off` rests on an interior newline that still precedes the closer: `if(off < mark->beg && ISNEWLINE(off))`. This restores the dropped space for whitespace-terminated lines and still suppresses it in the two cases the old guard covered: the opener's boundary-space jump (where `off` lands on next-line content, not a newline) and the closer's restored trailing whitespace (where `off` reaches the closer mark).

## Validation

Built `md2html` from this branch and compared raw output byte-for-byte against the spec's literal expected HTML. The three examples now match, and the boundary cases that must not regress are unchanged:

| # | Input | Before | After / spec |
|---|-------|--------|--------------|
| 335 | ``` ``\nfoo\nbar  \nbaz\n`` ``` | `<code>foo bar  baz</code>` | `<code>foo bar   baz</code>` |
| 337 | ``` `foo   bar \nbaz` ``` | `<code>foo   bar baz</code>` | `<code>foo   bar  baz</code>` |
| 640 | ``` `code  \nspan` ``` | `<code>code  span</code>` | `<code>code   span</code>` |
| 121 | ``` ``\nfoo\n`` ``` | `<code>foo</code>` | `<code>foo</code>` (unchanged) |
| 336 | ``` ``\nfoo \n`` ``` | `<code>foo </code>` | `<code>foo </code>` (unchanged) |

`test/run-testsuite.py` reports `652 passed, 0 failed` on `spec.txt` and `79 passed, 0 failed` on `regressions.txt` with the change, so it adds no regression there.

One caveat on the test suite: it doesn't exhibit the original bug. The vendored `test/normalize.py` collapses whitespace runs outside `<pre>`, so a one-space difference inside an inline `<code>` is normalized away before comparison. The discrepancy is only visible in raw output against the spec's literal HTML, which is likely why it has gone unnoticed. I found it byte-comparing md4c output against `spec.txt` in a downstream consumer.
