### PR TITLE
Add ESP-IDF / PlatformIO / Arduino packaging support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ project(MD4C
     LANGUAGES C
 )
 
+if(IDF_TARGET)
+    idf_component_register(
+        SRC_DIRS "src"
+        INCLUDE_DIRS "src"
+    )
+    return() # Stops executing the desktop configurations below when building for ESP32
+endif()
+
 option(BUILD_MD2HTML_EXECUTABLE "Whether to compile the md2html executable" ON)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,63 +6,68 @@ project(MD4C
     LANGUAGES C
 )
 
+configure_file(idf_component.yml.in    ${CMAKE_CURRENT_SOURCE_DIR}/idf_component.yml    @ONLY)
+configure_file(library.json.in         ${CMAKE_CURRENT_SOURCE_DIR}/library.json         @ONLY)
+configure_file(library.properties.in   ${CMAKE_CURRENT_SOURCE_DIR}/library.properties   @ONLY)
+
 if(IDF_TARGET)
     idf_component_register(
         SRC_DIRS "src"
         INCLUDE_DIRS "src"
     )
-    return() # Stops executing the desktop configurations below when building for ESP32
 endif()
 
-option(BUILD_MD2HTML_EXECUTABLE "Whether to compile the md2html executable" ON)
+if(NOT IDF_TARGET)
+    option(BUILD_MD2HTML_EXECUTABLE "Whether to compile the md2html executable" ON)
 
 
-if(WIN32)
-    # On Windows, given there is no standard lib install dir etc., we rather
-    # by default build static lib.
-    option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
-else()
-    # On Linux, MD4C is slowly being adding into some distros which prefer
-    # shared lib.
-    option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
-endif()
-
-set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo MinSizeRel)
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE $ENV{CMAKE_BUILD_TYPE})
-
-    if(NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE "Release")
+    if(WIN32)
+        # On Windows, given there is no standard lib install dir etc., we rather
+        # by default build static lib.
+        option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+    else()
+        # On Linux, MD4C is slowly being adding into some distros which prefer
+        # shared lib.
+        option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
     endif()
+
+    set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo MinSizeRel)
+    if(NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE $ENV{CMAKE_BUILD_TYPE})
+
+        if(NOT CMAKE_BUILD_TYPE)
+            set(CMAKE_BUILD_TYPE "Release")
+        endif()
+    endif()
+
+
+    if(CMAKE_C_COMPILER_ID MATCHES GNU|Clang)
+        add_compile_options(-Wall -Wextra -Wshadow)
+
+        # We enforce -Wdeclaration-after-statement because Qt project needs to
+        # build MD4C with Integrity compiler which chokes whenever a declaration
+        # is not at the beginning of a block.
+        add_compile_options(-Wdeclaration-after-statement)
+    elseif(MSVC)
+        # Disable warnings about the so-called unsecured functions:
+        add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+        add_compile_options(/W3)
+
+        # Specify proper C runtime library:
+        string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+        string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+        string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELWITHDEBINFO "{$CMAKE_C_FLAGS_RELWITHDEBINFO}")
+        string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
+        set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+        set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} /MT")
+        set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE} /MT")
+    endif()
+
+    include(GNUInstallDirs)
+
+    add_subdirectory(src)
+    if (BUILD_MD2HTML_EXECUTABLE)
+        add_subdirectory(md2html)
+    endif ()
 endif()
-
-
-if(CMAKE_C_COMPILER_ID MATCHES GNU|Clang)
-    add_compile_options(-Wall -Wextra -Wshadow)
-
-    # We enforce -Wdeclaration-after-statement because Qt project needs to
-    # build MD4C with Integrity compiler which chokes whenever a declaration
-    # is not at the beginning of a block.
-    add_compile_options(-Wdeclaration-after-statement)
-elseif(MSVC)
-    # Disable warnings about the so-called unsecured functions:
-    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-    add_compile_options(/W3)
-
-    # Specify proper C runtime library:
-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELWITHDEBINFO "{$CMAKE_C_FLAGS_RELWITHDEBINFO}")
-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} /MT")
-    set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE} /MT")
-endif()
-
-include(GNUInstallDirs)
-
-add_subdirectory(src)
-if (BUILD_MD2HTML_EXECUTABLE)
-    add_subdirectory(md2html)
-endif ()

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,17 @@
+version: "0.5.3"
+description: "Fast, SAX-like Markdown parser implementation in C compliant with the CommonMark specification."
+url: "https://github.com/mity/md4c"
+maintainers:
+  - "Martin Mitáš <https://github.com/mity>"
+targets:
+  - esp32
+  - esp32s2
+  - esp32s3
+  - esp32c2
+  - esp32c3
+  - esp32c6
+  - esp32h2
+  - esp32p4
+  - linux
+dependencies:
+  idf: ">=5.3"

--- a/idf_component.yml.in
+++ b/idf_component.yml.in
@@ -1,4 +1,4 @@
-version: "0.5.3"
+version: "@PROJECT_VERSION@"
 description: "Fast, SAX-like Markdown parser implementation in C compliant with the CommonMark specification."
 url: "https://github.com/mity/md4c"
 maintainers:

--- a/library.json
+++ b/library.json
@@ -1,0 +1,10 @@
+{
+  "name": "md4c",
+  "version": "0.4.7",
+  "description": "Markdown for C - CommonMark parser",
+  "build": {
+    "includeDir": "src",
+    "srcDir": "src",
+    "srcFilter": ["+<md4c.c>", "+<md4c-html.c>", "+<entity.c>"]
+  }
+}

--- a/library.json
+++ b/library.json
@@ -4,7 +4,6 @@
   "description": "Markdown for C - CommonMark parser",
   "build": {
     "includeDir": "src",
-    "srcDir": "src",
-    "srcFilter": ["+<md4c.c>", "+<md4c-html.c>", "+<entity.c>"]
+    "srcDir": "src"
   }
 }

--- a/library.json
+++ b/library.json
@@ -1,9 +1,37 @@
 {
   "name": "md4c",
-  "version": "0.4.7",
-  "description": "Markdown for C - CommonMark parser",
+  "version": "0.5.3",
+  "description": "Fast, SAX-like Markdown parser implementation in C compliant with the CommonMark specification.",
+  "keywords": [
+    "markdown",
+    "parser",
+    "commonmark",
+    "html",
+    "text"
+  ],
+  "authors": [
+    {
+      "name": "Martin Mitáš",
+      "url": "https://github.com/mity"
+    }
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/mity/md4c",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mity/md4c"
+  },
   "build": {
     "includeDir": "src",
     "srcDir": "src"
-  }
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "platforms": [
+    "espressif32",
+    "espressif8266",
+    "ststm32",
+    "raspberrypi"
+  ]
 }

--- a/library.json
+++ b/library.json
@@ -26,7 +26,8 @@
     "srcDir": "src"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "platforms": [
     "espressif32",

--- a/library.json.in
+++ b/library.json.in
@@ -1,6 +1,6 @@
 {
   "name": "md4c",
-  "version": "0.5.3",
+  "version": "@PROJECT_VERSION@",
   "description": "Fast, SAX-like Markdown parser implementation in C compliant with the CommonMark specification.",
   "keywords": [
     "markdown",

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=md4c
 version=0.5.3
-author=Martin Mitáš, TailsmanDesign
-maintainer=TailsmanDesign
+author=Martin Mitáš
+maintainer=Martin Mitáš
 sentence=Fast, SAX-like Markdown parser implementation in C.
 paragraph=A highly optimized Markdown parser compliant with the latest version of the CommonMark specification. Easy to stream and parse documents directly on embedded devices.
 category=Data Processing

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=md4c
+version=0.5.3
+author=Martin Mitáš, TailsmanDesign
+maintainer=TailsmanDesign
+sentence=Fast, SAX-like Markdown parser implementation in C.
+paragraph=A highly optimized Markdown parser compliant with the latest version of the CommonMark specification. Easy to stream and parse documents directly on embedded devices.
+category=Data Processing
+url=https://github.com/mity/md4c
+architectures=*
+includes=md4c.h
+license=MIT

--- a/library.properties.in
+++ b/library.properties.in
@@ -1,0 +1,11 @@
+name=md4c
+version=@PROJECT_VERSION@
+author=Martin Mitáš
+maintainer=Martin Mitáš
+sentence=Fast, SAX-like Markdown parser implementation in C.
+paragraph=A highly optimized Markdown parser compliant with the latest version of the CommonMark specification. Easy to stream and parse documents directly on embedded devices.
+category=Data Processing
+url=https://github.com/mity/md4c
+architectures=*
+includes=md4c.h
+license=MIT


### PR DESCRIPTION
Adds packaging metadata so md4c can be consumed as a component/library by embedded build systems, used for my app for the PocketMage (and possibly PocketMageOS later on).