### PR TITLE
Add optional blank line preservation (MD_FLAG_PRESERVEBLANKLINES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 New Features:
 
+  * Add blank line preservation, enabled with the flag
+    `MD_FLAG_PRESERVEBLANKLINES`.
+
+    Normally any run of blank lines separating two blocks is collapsed into a
+    single block boundary. With the flag, each run is instead reported as a
+    block `MD_BLOCK_BLANK` whose detail (`MD_BLOCK_BLANK_DETAIL`) holds the
+    number of blank lines. This is a deviation from CommonMark, intended for
+    WYSIWYG-like applications which need to reproduce the vertical spacing of
+    the source.
+
   * Add highlight span extension, enabled with the flag `MD_FLAG_HIGHLIGHT`.
 
     Syntax example:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ extensions:
 * With the flag `MD_FLAG_HARD_SOFT_BREAKS`, all soft breaks (newlines) in the
   Markdown input are treated as hard breaks (i.e. as `<br>` in HTML output).
 
+* With the flag `MD_FLAG_PRESERVEBLANKLINES`, each run of blank lines between
+  blocks is reported as a `MD_BLOCK_BLANK` carrying the number of blank lines,
+  instead of being collapsed into a single block boundary. This is a deviation
+  from CommonMark, intended for WYSIWYG-like applications.
+
 * With the flag `MD_FLAG_TABLES`, GitHub-style tables are supported.
 
 * With the flag `MD_FLAG_TASKLISTS`, GitHub-style task lists are supported.

--- a/md2html/md2html.1
+++ b/md2html/md2html.1
@@ -96,6 +96,10 @@ Allow WWW autolinks without any scheme (e.g., "www.example.com")
 Enable all 3 of the above permissive autolinks options
 .
 .TP
+.B --fpreserve-blank-lines
+Report blank line runs (as MD_BLOCK_BLANK)
+.
+.TP
 .B --fspoilers
 Enable spoiler spans (||hidden text||)
 .

--- a/md2html/md2html.1
+++ b/md2html/md2html.1
@@ -97,7 +97,7 @@ Enable all 3 of the above permissive autolinks options
 .
 .TP
 .B --fpreserve-blank-lines
-Report blank line runs (as MD_BLOCK_BLANK)
+Render extra blank lines between blocks as <br>.
 .
 .TP
 .B --fspoilers

--- a/md2html/md2html.c
+++ b/md2html/md2html.c
@@ -325,7 +325,7 @@ usage(void)
         "                       Same as --fpermissive-email-autolinks --fpermissive-url-autolinks\n"
         "                       --fpermissive-www-autolinks\n"
         "      --fpreserve-blank-lines\n"
-        "                       Report blank line runs (as MD_BLOCK_BLANK)\n"
+        "                       Render extra blank lines between blocks as <br>\n"
         "      --fhighlight    Enable highlight spans (==text==)\n"
         "      --fspoilers      Enable spoiler spans (||hidden text||)\n"
         "      --fstrikethrough Enable strike-through spans\n"

--- a/md2html/md2html.c
+++ b/md2html/md2html.c
@@ -262,6 +262,7 @@ static const CMDLINE_OPTION cmdline_options[] = {
     {  0,  "fpermissive-email-autolinks",   '@', 0 },
     {  0,  "fpermissive-url-autolinks",     'U', 0 },
     {  0,  "fpermissive-www-autolinks",     '.', 0 },
+    {  0,  "fpreserve-blank-lines",         'Y', 0 },
     {  0,  "fspoilers",                     'P', 0 },
     {  0,  "fstrikethrough",                'S', 0 },
     {  0,  "fsubscripts",                   '~', 0 },
@@ -323,6 +324,8 @@ usage(void)
         "      --fpermissive-autolinks\n"
         "                       Same as --fpermissive-email-autolinks --fpermissive-url-autolinks\n"
         "                       --fpermissive-www-autolinks\n"
+        "      --fpreserve-blank-lines\n"
+        "                       Report blank line runs (as MD_BLOCK_BLANK)\n"
         "      --fhighlight    Enable highlight spans (==text==)\n"
         "      --fspoilers      Enable spoiler spans (||hidden text||)\n"
         "      --fstrikethrough Enable strike-through spans\n"
@@ -413,6 +416,7 @@ cmdline_callback(int opt, char const* value, void* data)
         case '_':   parser_flags |= MD_FLAG_UNDERLINE; break;
         case 'N':   parser_flags |= MD_FLAG_FOOTNOTES; break;
         case 'B':   parser_flags |= MD_FLAG_HARD_SOFT_BREAKS; break;
+        case 'Y':   parser_flags |= MD_FLAG_PRESERVEBLANKLINES; break;
 
         default:
             fprintf(stderr, "Illegal option: %s\n", value);

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -426,6 +426,14 @@ render_close_footnote_def_block(MD_HTML* r, const MD_BLOCK_FOOTNOTE_DEF_DETAIL* 
     RENDER_VERBATIM(r, "\n</li>\n");
 }
 
+static void
+render_blank_block(MD_HTML* r, const MD_BLOCK_BLANK_DETAIL* det)
+{
+    unsigned i;
+    for(i = 0; i < det->count; i++)
+        RENDER_VERBATIM(r, "<p>&nbsp;</p>\n");
+}
+
 static int
 enter_block_callback(MD_BLOCKTYPE type, void* detail, void* userdata)
 {
@@ -452,6 +460,7 @@ enter_block_callback(MD_BLOCKTYPE type, void* detail, void* userdata)
         case MD_BLOCK_FOOTNOTE_DEF_SECTION: RENDER_VERBATIM(r, "<section class=\"footnotes\">\n<ol>\n"); break;
         case MD_BLOCK_FOOTNOTE_DEF: render_open_footnote_def_block(r, (MD_BLOCK_FOOTNOTE_DEF_DETAIL*)detail); break;
         case MD_BLOCK_ADMONITION:   render_open_admonition_block(r, (const MD_BLOCK_ADMONITION_DETAIL*) detail); break;
+        case MD_BLOCK_BLANK:    render_blank_block(r, (const MD_BLOCK_BLANK_DETAIL*) detail); break;
     }
 
     return 0;
@@ -483,6 +492,7 @@ leave_block_callback(MD_BLOCKTYPE type, void* detail, void* userdata)
         case MD_BLOCK_FOOTNOTE_DEF_SECTION: RENDER_VERBATIM(r, "</ol>\n</section>\n"); break;
         case MD_BLOCK_FOOTNOTE_DEF: render_close_footnote_def_block(r, (MD_BLOCK_FOOTNOTE_DEF_DETAIL*)detail); break;
         case MD_BLOCK_ADMONITION:   RENDER_VERBATIM(r, "</div>\n"); break;
+        case MD_BLOCK_BLANK:    /* noop (fully emitted on enter) */ break;
     }
 
     return 0;

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -430,8 +430,10 @@ static void
 render_blank_block(MD_HTML* r, const MD_BLOCK_BLANK_DETAIL* det)
 {
     unsigned i;
-    for(i = 0; i < det->count; i++)
-        RENDER_VERBATIM(r, "<p>&nbsp;</p>\n");
+    /* The first blank line is the ordinary block separation CommonMark already
+     * implies; render only the surplus (line_count - 1) as <br>. */
+    for(i = 1; i < det->line_count; i++)
+        RENDER_VERBATIM(r, (r->flags & MD_HTML_FLAG_XHTML) ? "<br/>\n" : "<br>\n");
 }
 
 static int

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -5497,7 +5497,7 @@ md_process_leaf_block(MD_CTX* ctx, MD_BLOCK* block)
             break;
 
         case MD_BLOCK_BLANK:
-            det.blank.count = block->data;
+            det.blank.line_count = block->data;
             break;
 
         default:
@@ -5865,9 +5865,7 @@ md_add_line_into_current_block(MD_CTX* ctx, const MD_LINE_ANALYSIS* analysis)
     return 0;
 }
 
-/* Report any pending blank lines as a single MD_BLOCK_BLANK. Called just before
- * a leaf or container block is pushed, so the blank block lands on the correct
- * side of the boundary. No-op unless MD_FLAG_PRESERVEBLANKLINES is enabled. */
+/* Part of the MD_FLAG_PRESERVEBLANKLINES implementation. */
 static int
 md_flush_blank_lines(MD_CTX* ctx)
 {

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -275,6 +275,10 @@ struct MD_CTX_tag {
     int n_block_bytes;
     int alloc_block_bytes;
 
+    /* Pending count of blank lines not yet reported as MD_BLOCK_BLANK.
+     * Used only with MD_FLAG_PRESERVEBLANKLINES. */
+    unsigned n_blank_lines;
+
     /* For container block analysis. */
     MD_CONTAINER* containers;
     int n_containers;
@@ -5432,6 +5436,7 @@ md_process_leaf_block(MD_CTX* ctx, MD_BLOCK* block)
         MD_BLOCK_H_DETAIL header;
         MD_BLOCK_CODE_DETAIL code;
         MD_BLOCK_TABLE_DETAIL table;
+        MD_BLOCK_BLANK_DETAIL blank;
     } det;
     MD_ATTRIBUTE_BUILD info_build = { 0 };
     MD_ATTRIBUTE_BUILD lang_build = { 0 };
@@ -5491,6 +5496,10 @@ md_process_leaf_block(MD_CTX* ctx, MD_BLOCK* block)
             det.table.body_row_count = block->n_lines - 2;
             break;
 
+        case MD_BLOCK_BLANK:
+            det.blank.count = block->data;
+            break;
+
         default:
             /* Noop. */
             break;
@@ -5502,7 +5511,8 @@ md_process_leaf_block(MD_CTX* ctx, MD_BLOCK* block)
     /* Process the block contents accordingly to is type. */
     switch(block->type) {
         case MD_BLOCK_HR:
-            /* noop */
+        case MD_BLOCK_BLANK:
+            /* noop (no contents) */
             break;
 
         case MD_BLOCK_CODE:
@@ -5855,6 +5865,30 @@ md_add_line_into_current_block(MD_CTX* ctx, const MD_LINE_ANALYSIS* analysis)
     return 0;
 }
 
+/* Report any pending blank lines as a single MD_BLOCK_BLANK. Called just before
+ * a leaf or container block is pushed, so the blank block lands on the correct
+ * side of the boundary. No-op unless MD_FLAG_PRESERVEBLANKLINES is enabled. */
+static int
+md_flush_blank_lines(MD_CTX* ctx)
+{
+    MD_BLOCK* block;
+
+    if(ctx->n_blank_lines == 0)
+        return 0;
+
+    block = (MD_BLOCK*) md_push_block_bytes(ctx, sizeof(MD_BLOCK));
+    if(block == NULL)
+        return -1;
+
+    block->type = MD_BLOCK_BLANK;
+    block->flags = 0;
+    block->data = ctx->n_blank_lines;
+    block->n_lines = 0;
+
+    ctx->n_blank_lines = 0;
+    return 0;
+}
+
 static int
 md_push_container_bytes(MD_CTX* ctx, MD_BLOCKTYPE type, unsigned start,
                         unsigned data, unsigned flags)
@@ -5862,6 +5896,7 @@ md_push_container_bytes(MD_CTX* ctx, MD_BLOCKTYPE type, unsigned start,
     MD_BLOCK* block;
     int ret = 0;
 
+    MD_CHECK(md_flush_blank_lines(ctx));
     MD_CHECK(md_end_current_block(ctx));
 
     block = (MD_BLOCK*) md_push_block_bytes(ctx, sizeof(MD_BLOCK));
@@ -6988,9 +7023,18 @@ md_process_line(MD_CTX* ctx, const MD_LINE_ANALYSIS** p_pivot_line, MD_LINE_ANAL
     /* Blank line ends current leaf block. */
     if(line->type == MD_LINE_BLANK) {
         MD_CHECK(md_end_current_block(ctx));
+        /* Count only genuinely empty lines: some non-blank lines (e.g. a closing
+         * code fence) are internally retyped as MD_LINE_BLANK but still hold
+         * their text (beg < end), and must not be counted. */
+        if((ctx->parser.flags & MD_FLAG_PRESERVEBLANKLINES)  &&  line->beg >= line->end)
+            ctx->n_blank_lines++;
         *p_pivot_line = &md_dummy_blank_line;
         return 0;
     }
+
+    /* The blank lines preceding this block (if any) form a block separation
+     * which we report before the block itself. */
+    MD_CHECK(md_flush_blank_lines(ctx));
 
     if(line->enforce_new_block)
         MD_CHECK(md_end_current_block(ctx));
@@ -7150,6 +7194,8 @@ md_process_doc(MD_CTX *ctx)
 
     /* Process all blocks. */
     MD_CHECK(md_leave_child_containers(ctx, 0));
+    /* Report any blank lines trailing the document. */
+    MD_CHECK(md_flush_blank_lines(ctx));
     MD_CHECK(md_process_all_blocks(ctx));
 
     /* Emit footnote definitions that were referenced, in reference order. */

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -370,7 +370,7 @@ typedef struct MD_BLOCK_FOOTNOTE_DEF_DETAIL {
 
 /* Detailed info for MD_BLOCK_BLANK. */
 typedef struct MD_BLOCK_BLANK_DETAIL {
-    unsigned count;         /* Count of blank lines forming the block separation */
+    unsigned line_count;    /* Count of blank lines forming the block separation */
 } MD_BLOCK_BLANK_DETAIL;
 
 /* Flags specifying extensions/deviations from CommonMark specification.

--- a/src/md4c.h
+++ b/src/md4c.h
@@ -118,7 +118,12 @@ typedef enum MD_BLOCKTYPE {
     /* Adminition extension.
      * Detail MD_BLOCK_ADMONITION_DETAIL.
      * Note: Recognized only when MD_FLAG_ADMONITIONS is enabled. */
-    MD_BLOCK_ADMONITION
+    MD_BLOCK_ADMONITION,
+
+    /* A run of blank lines separating two blocks. Has no contents.
+     * Detail: Structure MD_BLOCK_BLANK_DETAIL.
+     * Note: Emitted only when MD_FLAG_PRESERVEBLANKLINES is enabled. */
+    MD_BLOCK_BLANK
 } MD_BLOCKTYPE;
 
 /* Span represents an in-line piece of a document which should be rendered with
@@ -363,6 +368,11 @@ typedef struct MD_BLOCK_FOOTNOTE_DEF_DETAIL {
     MD_ATTRIBUTE label;     /* Raw label text */
 } MD_BLOCK_FOOTNOTE_DEF_DETAIL;
 
+/* Detailed info for MD_BLOCK_BLANK. */
+typedef struct MD_BLOCK_BLANK_DETAIL {
+    unsigned count;         /* Count of blank lines forming the block separation */
+} MD_BLOCK_BLANK_DETAIL;
+
 /* Flags specifying extensions/deviations from CommonMark specification.
  *
  * By default (when MD_PARSER::flags == 0), we follow CommonMark specification.
@@ -389,6 +399,7 @@ typedef struct MD_BLOCK_FOOTNOTE_DEF_DETAIL {
 #define MD_FLAG_ADMONITIONS                 0x80000 /* Enable admonitions extension. */
 #define MD_FLAG_FOOTNOTES                   0x100000 /* Enable [^label] footnote references. */
 #define MD_FLAG_HIGHLIGHT                   0x200000 /* Enable ==highlight== spans. */
+#define MD_FLAG_PRESERVEBLANKLINES          0x400000 /* Report blank line runs as MD_BLOCK_BLANK. */
 
 #define MD_FLAG_PERMISSIVEAUTOLINKS         (MD_FLAG_PERMISSIVEEMAILAUTOLINKS | MD_FLAG_PERMISSIVEURLAUTOLINKS | MD_FLAG_PERMISSIVEWWWAUTOLINKS)
 #define MD_FLAG_NOHTML                      (MD_FLAG_NOHTMLBLOCKS | MD_FLAG_NOHTMLSPANS)

--- a/test/coverage.txt
+++ b/test/coverage.txt
@@ -326,8 +326,7 @@ after
 .
 <div>
 x
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <p>after</p>
 .
 --fpreserve-blank-lines
@@ -345,8 +344,7 @@ makes the list loose):
 .
 <ul>
 <li><p>a</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 </li>
 <li><p>b</p>
 </li>
@@ -367,8 +365,7 @@ para
 .
 <ul>
 <li>a</li>
-<li>b<p>&nbsp;</p>
-<p>&nbsp;</p>
+<li>b<br>
 </li>
 </ul>
 <p>para</p>
@@ -388,8 +385,7 @@ container (here the inner list item inside the block quote):
 <blockquote>
 <ul>
 <li><p>a</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 </li>
 <li><p>b</p>
 </li>
@@ -399,16 +395,40 @@ container (here the inner list item inside the block quote):
 --fpreserve-blank-lines
 ````````````````````````````````
 
+Blank lines are split on a container boundary honouring proper nesting: a run
+of blank lines that continues the block quote (with the `>` mark) is reported
+inside it, while a following run of blank lines that no longer continues it is
+reported at the outer level:
+
+```````````````````````````````` example
+> quote with trailing blank lines inside of it.
+>
+>
+
+
+after the block quote.
+.
+<blockquote>
+<p>quote with trailing blank lines inside of it.</p>
+<br>
+</blockquote>
+<br>
+<p>after the block quote.</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
 A line consisting only of spaces or tabs is a blank line and is counted (the
-second line below contains three spaces):
+second and third lines below contain three spaces each):
 
 ```````````````````````````````` example
 foo
    
+   
 bar
 .
 <p>foo</p>
-<p>&nbsp;</p>
+<br>
 <p>bar</p>
 .
 --fpreserve-blank-lines
@@ -429,14 +449,11 @@ para
 end
 .
 <p>para</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <h1>H</h1>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <hr>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <p>end</p>
 .
 --fpreserve-blank-lines

--- a/test/coverage.txt
+++ b/test/coverage.txt
@@ -295,3 +295,149 @@ foo  bar → baz
 .
 --fcollapse-whitespace
 ````````````````````````````````
+
+
+## Flag `MD_FLAG_PRESERVEBLANKLINES`
+
+A closing code fence is internally retyped as a blank line but still holds its
+text, so it must not be counted as a blank line separation.
+
+```````````````````````````````` example
+```
+foo
+```
+bar
+.
+<pre><code>foo
+</code></pre>
+<p>bar</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+A blank line ending an HTML block is a genuine blank line and is reported.
+
+```````````````````````````````` example
+<div>
+x
+
+
+after
+.
+<div>
+x
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>after</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines attach to the innermost container open where they occur. Blank
+lines between two list items are reported inside the preceding item (which also
+makes the list loose):
+
+```````````````````````````````` example
+* a
+
+
+* b
+.
+<ul>
+<li><p>a</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+</li>
+<li><p>b</p>
+</li>
+</ul>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Consistently, blank lines trailing the last item (before a following paragraph
+that ends the list) are reported inside that last item:
+
+```````````````````````````````` example
+* a
+* b
+
+
+para
+.
+<ul>
+<li>a</li>
+<li>b<p>&nbsp;</p>
+<p>&nbsp;</p>
+</li>
+</ul>
+<p>para</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines nested several containers deep attach to the innermost open
+container (here the inner list item inside the block quote):
+
+```````````````````````````````` example
+> * a
+>
+>
+> * b
+.
+<blockquote>
+<ul>
+<li><p>a</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+</li>
+<li><p>b</p>
+</li>
+</ul>
+</blockquote>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+A line consisting only of spaces or tabs is a blank line and is counted (the
+second line below contains three spaces):
+
+```````````````````````````````` example
+foo
+   
+bar
+.
+<p>foo</p>
+<p>&nbsp;</p>
+<p>bar</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines neighbouring an ATX heading and a thematic break are reported:
+
+```````````````````````````````` example
+para
+
+
+# H
+
+
+---
+
+
+end
+.
+<p>para</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<h1>H</h1>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<hr>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>end</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````

--- a/test/spec-preserve-blank-lines.txt
+++ b/test/spec-preserve-blank-lines.txt
@@ -1,0 +1,194 @@
+
+# Preserve blank lines
+
+By default MD4C (like CommonMark) treats any run of blank lines between two
+blocks as a single block boundary and discards how many blank lines it
+consisted of.
+
+With the flag `MD_FLAG_PRESERVEBLANKLINES`, each such run is instead reported
+as a single block `MD_BLOCK_BLANK` whose detail (`MD_BLOCK_BLANK_DETAIL`) holds
+the count of blank lines forming the separation. This lets applications
+reproduce the vertical spacing of the source; it is a deviation from
+CommonMark.
+
+The `md2html` renderer used for these tests renders each such block as `count`
+paragraphs holding a non-breaking space, so the count is visible in the output.
+
+A run of several blank lines between two blocks is reported with its full
+count:
+
+```````````````````````````````` example
+Paragraph one.
+
+
+
+Paragraph two.
+.
+<p>Paragraph one.</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>Paragraph two.</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Even an ordinary single blank line separating two blocks is reported (with
+count 1):
+
+```````````````````````````````` example
+foo
+
+bar
+.
+<p>foo</p>
+<p>&nbsp;</p>
+<p>bar</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines leading the document are reported:
+
+```````````````````````````````` example
+
+
+foo
+.
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>foo</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines trailing the document are reported:
+
+```````````````````````````````` example
+foo
+
+
+.
+<p>foo</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines preceding a container are reported before it:
+
+```````````````````````````````` example
+foo
+
+
+> quote
+.
+<p>foo</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<blockquote>
+<p>quote</p>
+</blockquote>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines inside a block quote are reported inside it:
+
+```````````````````````````````` example
+> foo
+>
+>
+> bar
+.
+<blockquote>
+<p>foo</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>bar</p>
+</blockquote>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines inside a block quote followed by blank lines after it are split on
+the boundary: the ones inside the quote are reported inside it, and the ones
+after it are reported at the outer level.
+
+```````````````````````````````` example
+> foo
+>
+>
+
+bar
+.
+<blockquote>
+<p>foo</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+</blockquote>
+<p>&nbsp;</p>
+<p>bar</p>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines separating two block quotes are reported between them:
+
+```````````````````````````````` example
+> foo
+
+
+> bar
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<blockquote>
+<p>bar</p>
+</blockquote>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Blank lines inside a fenced code block are part of its verbatim contents and
+are not reported as `MD_BLOCK_BLANK`:
+
+```````````````````````````````` example
+```
+foo
+
+
+
+bar
+```
+.
+<pre><code>foo
+
+
+
+bar
+</code></pre>
+.
+--fpreserve-blank-lines
+````````````````````````````````
+
+Likewise, blank lines inside an indented code block are not reported:
+
+```````````````````````````````` example
+    foo
+
+
+    bar
+.
+<pre><code>foo
+
+
+bar
+</code></pre>
+.
+--fpreserve-blank-lines
+````````````````````````````````

--- a/test/spec-preserve-blank-lines.txt
+++ b/test/spec-preserve-blank-lines.txt
@@ -11,11 +11,13 @@ the count of blank lines forming the separation. This lets applications
 reproduce the vertical spacing of the source; it is a deviation from
 CommonMark.
 
-The `md2html` renderer used for these tests renders each such block as `count`
-paragraphs holding a non-breaking space, so the count is visible in the output.
+The `md2html` renderer used for these tests renders a run of `line_count` blank
+lines as `line_count - 1` `<br>` elements: one blank line is the ordinary block
+separation CommonMark already implies (and is already visible as the boundary
+between the two blocks), so only the surplus blank lines are shown.
 
-A run of several blank lines between two blocks is reported with its full
-count:
+A run of several blank lines between two blocks renders as `line_count - 1`
+`<br>` elements:
 
 ```````````````````````````````` example
 Paragraph one.
@@ -25,16 +27,17 @@ Paragraph one.
 Paragraph two.
 .
 <p>Paragraph one.</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
+<br>
 <p>Paragraph two.</p>
 .
 --fpreserve-blank-lines
 ````````````````````````````````
 
-Even an ordinary single blank line separating two blocks is reported (with
-count 1):
+An ordinary single blank line separating two blocks is still reported by the
+parser (as a `MD_BLOCK_BLANK` with `line_count` 1), but this renderer shows
+nothing extra for it, as that first blank line is the block separation already
+implied by the boundary between the two paragraphs:
 
 ```````````````````````````````` example
 foo
@@ -42,7 +45,6 @@ foo
 bar
 .
 <p>foo</p>
-<p>&nbsp;</p>
 <p>bar</p>
 .
 --fpreserve-blank-lines
@@ -55,8 +57,7 @@ Blank lines leading the document are reported:
 
 foo
 .
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <p>foo</p>
 .
 --fpreserve-blank-lines
@@ -70,8 +71,7 @@ foo
 
 .
 <p>foo</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 .
 --fpreserve-blank-lines
 ````````````````````````````````
@@ -85,8 +85,7 @@ foo
 > quote
 .
 <p>foo</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <blockquote>
 <p>quote</p>
 </blockquote>
@@ -104,8 +103,7 @@ Blank lines inside a block quote are reported inside it:
 .
 <blockquote>
 <p>foo</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <p>bar</p>
 </blockquote>
 .
@@ -125,10 +123,8 @@ bar
 .
 <blockquote>
 <p>foo</p>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 </blockquote>
-<p>&nbsp;</p>
 <p>bar</p>
 .
 --fpreserve-blank-lines
@@ -145,8 +141,7 @@ Blank lines separating two block quotes are reported between them:
 <blockquote>
 <p>foo</p>
 </blockquote>
-<p>&nbsp;</p>
-<p>&nbsp;</p>
+<br>
 <blockquote>
 <p>bar</p>
 </blockquote>


### PR DESCRIPTION
Closes #384.

## Motivation

When rendering from the MD4C callback stream (e.g. building a native view tree for a WYSIWYG-like editor), the number of blank lines the author typed between blocks is meaningful. CommonMark collapses any run of blank lines into a single block boundary, and MD4C discards this information in the process so it can't be recovered downstream without pre-processing the source. This adds an opt-in way to get that information from the parser.

## What this does

Adds the flag `MD_FLAG_PRESERVEBLANKLINES`. When enabled, each run of blank lines separating two blocks is reported as a single new block `MD_BLOCK_BLANK`, whose detail `MD_BLOCK_BLANK_DETAIL` carries the number of blank lines:

```c
  typedef struct MD_BLOCK_BLANK_DETAIL {
      unsigned count;   /* Count of blank lines forming the block separation */
  } MD_BLOCK_BLANK_DETAIL;
```

Following the discussion in #384, the run is coalesced into one block (the count is stored once, not one block per line), and all blank lines are reported - i.e. the arser reports "this block separation is made of N blank lines" and leaves the rendering decision to the application.

With the flag off, behaviour and output are byte-for-byte unchanged.

## Semantics

- One `MD_BLOCK_BLANK` per run; no `MD_TEXT` is sent.
- Blank lines attach to the innermost open container and flush at the next block boundary, so runs split correctly across edges: blanks inside a block quote are reported inside it, blanks after it at the outer level (and vice versa).
- Only genuinely empty lines are counted. Blank lines inside code blocks are verbatim content, and a few non-blank lines MD4C internally treats as blank (a closing code fence, an admonition tag) are excluded.

md2html gains --fpreserve-blank-lines; its renderer emits count non-breaking-space paragraphs so the count is visible/testable.

*Note: Blank lines trailing a list's last item (before a dedented paragraph that ends the list) currently attach inside that last `<li>`, consistent with the "innermost open container" rule. Happy to tweak those semantics, if you'd prefer. Documented with a test in `test/coverage.txt`*

### Tests & docs

- New test/spec-preserve-blank-lines.txt (10 examples, doubling as docs) plus harder paths in test/coverage.txt (closing-fence exclusion, HTML-end blank, loose lists, trailing-in-item, nested containers, whitespace-only lines).
- Full suite green; -Werror Debug + Release clean. `CRLF` verified manually but not added as a spec test (the .txt files are LF-only).
- README, CHANGELOG, md2html man page, and md4c.h doc comments updated.
