### PR TITLE
README.md: Add a link to md4c gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ MD4C is covered with MIT license, see the file `LICENSE.md`.
 
 Bindings:
 
+* [md4c gem](https://codeberg.org/gemmaro/ruby-md4c):
+  Ruby bindings.
+
 * [md4lean](https://github.com/acmepjz/md4lean):
   [Lean](https://lean-lang.org/) bindings.
 


### PR DESCRIPTION
Hello,

I have made a CRuby binding for MD4C, and this adds the link to it.

Thank you,