### PR TITLE
Replace fall through comments with MD_FALLTHROUGH macro

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -45,6 +45,15 @@
     #define snprintf _snprintf
 #endif
 
+/* For falling through case labels in switch statements. */
+#if defined __clang__ && __clang_major__ >= 12
+    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+#elif defined __GNUC__ && __GNUC__ >= 7
+    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+#else
+    #define MD_FALLTHROUGH()        ((void)0)
+#endif
+
 
 
 typedef struct MD_HTML_tag MD_HTML;
@@ -568,7 +577,7 @@ leave_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "</sup>"); break;
         case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "</sub>"); break;
         case MD_SPAN_MARK:              RENDER_VERBATIM(r, "</mark>"); break;
-        case MD_SPAN_LATEXMATH:         /*fall through*/
+        case MD_SPAN_LATEXMATH:         MD_FALLTHROUGH();
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "</x-equation>"); break;
         case MD_SPAN_WIKILINK:          RENDER_VERBATIM(r, "</x-wikilink>"); break;
         case MD_SPAN_FOOTNOTE_REF:      /* noop: enter_span already emitted full HTML */ break;

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4590,17 +4590,17 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
 
         /* Analyze the mark. */
         switch(mark->ch) {
-            case '[':   /* Pass through. */
-            case '!':   /* Pass through. */
+            case '[':   MD_FALLTHROUGH();
+            case '!':   MD_FALLTHROUGH();
             case ']':   md_analyze_bracket(ctx, i); break;
             case '&':   md_analyze_entity(ctx, i); break;
-            case '_':   /* Pass through. */
+            case '_':   MD_FALLTHROUGH();
             case '*':   md_analyze_emph(ctx, i); break;
             case '~':   md_analyze_tilde(ctx, i); break;
             case '^':   md_analyze_caret(ctx, i); break;
             case '$':   md_analyze_dollar(ctx, i); break;
-            case '.':   /* Pass through. */
-            case ':':   /* Pass through. */
+            case '.':   MD_FALLTHROUGH();
+            case ':':   MD_FALLTHROUGH();
             case '@':   md_analyze_permissive_autolink(ctx, i); break;
             case '|':   md_analyze_spoiler(ctx, i); break;
             case '=':   md_analyze_highlight(ctx, i); break;
@@ -6297,7 +6297,7 @@ md_is_html_block_end_condition(MD_CTX* ctx, OFF beg, OFF* p_end)
         case 5:
             return (md_line_contains(ctx, beg, _T("]]>"), 3, p_end) ? 5 : FALSE);
 
-        case 6:     /* Pass through */
+        case 6:     MD_FALLTHROUGH();
         case 7:
             if(beg >= ctx->size  ||  ISNEWLINE(beg)) {
                 /* Blank line ends types 6 and 7. */


### PR DESCRIPTION
Replace pass through and fall through comments with MD_FALLTHROUGH macro. Add macro to md4c-html