### PR TITLE
Remove redefinition of MD_FOOTNOTE_DEF

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2013,7 +2013,6 @@ md_lookup_ref_def(MD_CTX* ctx, const CHAR* label, SZ label_size)
  ***  Footnote Definitions   ***
  *******************************/
 
-typedef struct MD_FOOTNOTE_DEF_tag MD_FOOTNOTE_DEF;
 struct MD_FOOTNOTE_DEF_tag {
     MD_LABEL_HASH_ENTRY entry;
     unsigned int index;         /* 0 = unreferenced; 1-based order of first reference */


### PR DESCRIPTION
MD_FOOTNOTE_DEF is first defined on [line 146](https://github.com/mity/md4c/blob/master/src/md4c.c#L146)