### PR TITLE
Build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 project(MD4C
     VERSION "0.5.3"
@@ -6,9 +6,35 @@ project(MD4C
     LANGUAGES C
 )
 
-configure_file(idf_component.yml.in    ${CMAKE_CURRENT_SOURCE_DIR}/idf_component.yml    @ONLY)
-configure_file(library.json.in         ${CMAKE_CURRENT_SOURCE_DIR}/library.json         @ONLY)
-configure_file(library.properties.in   ${CMAKE_CURRENT_SOURCE_DIR}/library.properties   @ONLY)
+# Some embedded platforms need the following files to exist even before
+# CMake's configure time. Hence we have them directly in the repo, but lets
+# at least check, they're up to date.
+#
+# If not, after a review of the generated one in the build dir need to be
+# committed as replacement of the respective pre-generated one. Unless we
+# do some really significant change like directory restructuring or introduce
+# some lib dependencies, it should be just about keeping the version in sync
+# between these files.
+configure_file(idf_component.yml.in    idf_component.yml.expected    @ONLY)
+configure_file(library.json.in         library.json.expected         @ONLY)
+configure_file(library.properties.in   library.properties.expected   @ONLY)
+
+function(CheckPregeneratedFile rel_path)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
+        ${CMAKE_SOURCE_DIR}/${rel_path}
+        ${CMAKE_BINARY_DIR}/${rel_path}.expected
+        RESULT_VARIABLE compare_result
+    )
+    if(NOT compare_result EQUAL 0)
+        message(FATAL_ERROR "The pre-generated ${rel_path} file is not up to date.")
+    endif()
+endfunction()
+
+CheckPregeneratedFile(idf_component.yml)
+CheckPregeneratedFile(library.json)
+CheckPregeneratedFile(library.properties)
+
 
 if(IDF_TARGET)
     idf_component_register(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,18 +18,42 @@ if(IDF_TARGET)
 endif()
 
 if(NOT IDF_TARGET)
-    option(BUILD_MD2HTML_EXECUTABLE "Whether to compile the md2html executable" ON)
-
-
+    # Some heuristics for what targets (and how) we actually build:
+    set(BUILD_SHARED_LIBS_default ON)
+    set(BUILD_HTML_LIBRARY_default ON)
+    set(BUILDMD2HTML_EXECUTABLE_default ON)
     if(WIN32)
-        # On Windows, given there is no standard lib install dir etc., we rather
-        # by default build static lib.
-        option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
-    else()
-        # On Linux, MD4C is slowly being adding into some distros which prefer
-        # shared lib.
-        option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+        # On Windows, given there is no standard lib install dir etc., we
+        # rather by default build static lib.
+        set(BUILD_SHARED_LIBS_default OFF)
     endif()
+    if(NOT PROJECT_IS_TOP_LEVEL)
+        # When we're embedded into a bigger project, most likely the outer
+        # project only needs the libs.
+        set(BUILDMD2HTML_EXECUTABLE_default OFF)
+    endif()
+
+    # Allow the user to override the defaults:
+    option(
+        BUILD_SHARED_LIBS
+        "Build using shared libraries"
+        ${BUILD_SHARED_LIBS_default}
+    )
+    option(
+        BUILD_HTML_LIBRARY
+        "Whether to compile the libmd-html library"
+        ${BUILD_HTML_LIBRARY_default}
+    )
+    option(
+        BUILD_MD2HTML_EXECUTABLE
+        "Whether to compile the md2html command line tool (requires libmd-html)"
+        ${BUILDMD2HTML_EXECUTABLE_default}
+    )
+
+    if(BUILD_MD2HTML_EXECUTABLE AND NOT BUILD_HTML_LIBRARY)
+        message(FATAL_ERROR "BUILD_MD2HTML_EXECUTABLE requires BUILD_HTML_LIBRARY=ON")
+    endif()
+
 
     set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo MinSizeRel)
     if(NOT CMAKE_BUILD_TYPE)
@@ -39,7 +63,6 @@ if(NOT IDF_TARGET)
             set(CMAKE_BUILD_TYPE "Release")
         endif()
     endif()
-
 
     if(CMAKE_C_COMPILER_ID MATCHES GNU|Clang)
         add_compile_options(-Wall -Wextra -Wshadow)
@@ -67,7 +90,5 @@ if(NOT IDF_TARGET)
     include(GNUInstallDirs)
 
     add_subdirectory(src)
-    if (BUILD_MD2HTML_EXECUTABLE)
-        add_subdirectory(md2html)
-    endif ()
+    add_subdirectory(md2html)
 endif()

--- a/md2html/CMakeLists.txt
+++ b/md2html/CMakeLists.txt
@@ -1,18 +1,16 @@
-# Build rules for md2html command line utility
 
-add_executable(md2html cmdline.c cmdline.h md2html.c)
-target_link_libraries(md2html PRIVATE md4c-html)
-target_compile_definitions(md2html PRIVATE
-    MD_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
-    MD_VERSION_MINOR=${PROJECT_VERSION_MINOR}
-    MD_VERSION_RELEASE=${PROJECT_VERSION_PATCH}
-)
-
-
-# Install rules
-
-install(
-    TARGETS md2html
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-install(FILES "md2html.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+# Build & install rules for md2html command line utility
+if(BUILD_MD2HTML_EXECUTABLE)
+    add_executable(md2html cmdline.c cmdline.h md2html.c)
+    target_link_libraries(md2html PRIVATE md4c-html)
+    target_compile_definitions(md2html PRIVATE
+        MD_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+        MD_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+        MD_VERSION_RELEASE=${PROJECT_VERSION_PATCH}
+    )
+    install(
+        TARGETS md2html
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    install(FILES "md2html.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,8 +5,7 @@ include(JoinPaths.cmake) # can be replaced by cmake_path(APPEND) in CMake 3.20
 join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 join_paths(PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 
-# Build rules for MD4C parser library
-
+# Build & install rules for MD4C parser library
 configure_file(md4c.pc.in md4c.pc @ONLY)
 add_library(md4c md4c.c md4c.h)
 target_include_directories(md4c PUBLIC
@@ -19,25 +18,6 @@ set_target_properties(md4c PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
     PUBLIC_HEADER md4c.h
 )
-
-# Build rules for HTML renderer library
-
-configure_file(md4c-html.pc.in md4c-html.pc @ONLY)
-add_library(md4c-html md4c-html.c md4c-html.h entity.c entity.h)
-target_include_directories(md4c-html PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-)
-set_target_properties(md4c-html PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION ${PROJECT_VERSION_MAJOR}
-    PUBLIC_HEADER md4c-html.h
-)
-target_link_libraries(md4c-html PUBLIC md4c)
-
-
-# Install rules
-
 install(
     TARGETS md4c
     EXPORT md4cConfig
@@ -48,14 +28,30 @@ install(
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/md4c.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-install(
-    TARGETS md4c-html
-    EXPORT md4cConfig
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/md4c-html.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+# Build & install rules for HTML renderer library
+if(BUILD_HTML_LIBRARY)
+    configure_file(md4c-html.pc.in md4c-html.pc @ONLY)
+    add_library(md4c-html md4c-html.c md4c-html.h entity.c entity.h)
+    target_include_directories(md4c-html PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    )
+    set_target_properties(md4c-html PROPERTIES
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        PUBLIC_HEADER md4c-html.h
+    )
+    target_link_libraries(md4c-html PUBLIC md4c)
+    install(
+        TARGETS md4c-html
+        EXPORT md4cConfig
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/md4c-html.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
 
+# Install rules
 install(EXPORT md4cConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/md4c/ NAMESPACE md4c::)


### PR DESCRIPTION
 * Separate heuristics of the default behavior from actual `option()` declaration.

 * Added new option `BUILD_HTML_LIBRARY` allowing to enable/disable build of our HTML renderer library.

 * By default set `BUILD_MD2HTML_EXECUTABLE` to `ON` only when we're being built as a top-level project. (I assume when another project embeds us, it's usually only interested in our lib target(s)).

 * Abort with an error when the set options cannot be adhered due to their inter-dependency.

 * For the sake of consistency, move logic of adhering the option `BUILD_MD2HTML_EXECUTABLE` from the top-level `CMakeLists.txt` to `md2html/CMakeLists.txt`.

 * Change handling of the `idf_components.yml`, `library.json` and `library.properties` files to a "configure-time assertion" instead of rewriting the pre-generated files in the source directory.