### PR TITLE
Fix a -Wpedantic warning related to MD_FALLTHROUGH.

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -47,9 +47,9 @@
 
 /* For falling through case labels in switch statements. */
 #if defined __clang__ && __clang_major__ >= 12
-    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+    #define MD_FALLTHROUGH()        ;__attribute__((fallthrough))
 #elif defined __GNUC__ && __GNUC__ >= 7
-    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+    #define MD_FALLTHROUGH()        ;__attribute__((fallthrough))
 #else
     #define MD_FALLTHROUGH()        ((void)0)
 #endif
@@ -579,7 +579,7 @@ leave_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "</sup>"); break;
         case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "</sub>"); break;
         case MD_SPAN_MARK:              RENDER_VERBATIM(r, "</mark>"); break;
-        case MD_SPAN_LATEXMATH:         {MD_FALLTHROUGH();}
+        case MD_SPAN_LATEXMATH:         MD_FALLTHROUGH();
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "</x-equation>"); break;
         case MD_SPAN_WIKILINK:          RENDER_VERBATIM(r, "</x-wikilink>"); break;
         case MD_SPAN_FOOTNOTE_REF:      /* noop: enter_span already emitted full HTML */ break;

--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -579,7 +579,7 @@ leave_span_callback(MD_SPANTYPE type, void* detail, void* userdata)
         case MD_SPAN_SUPERSCRIPT:       RENDER_VERBATIM(r, "</sup>"); break;
         case MD_SPAN_SUBSCRIPT:         RENDER_VERBATIM(r, "</sub>"); break;
         case MD_SPAN_MARK:              RENDER_VERBATIM(r, "</mark>"); break;
-        case MD_SPAN_LATEXMATH:         MD_FALLTHROUGH();
+        case MD_SPAN_LATEXMATH:         {MD_FALLTHROUGH();}
         case MD_SPAN_LATEXMATH_DISPLAY: RENDER_VERBATIM(r, "</x-equation>"); break;
         case MD_SPAN_WIKILINK:          RENDER_VERBATIM(r, "</x-wikilink>"); break;
         case MD_SPAN_FOOTNOTE_REF:      /* noop: enter_span already emitted full HTML */ break;

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -4635,17 +4635,17 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
 
         /* Analyze the mark. */
         switch(mark->ch) {
-            case '[':   MD_FALLTHROUGH();
-            case '!':   MD_FALLTHROUGH();
+            case '[':   {MD_FALLTHROUGH();}
+            case '!':   {MD_FALLTHROUGH();}
             case ']':   md_analyze_bracket(ctx, i); break;
             case '&':   md_analyze_entity(ctx, i); break;
-            case '_':   MD_FALLTHROUGH();
+            case '_':   {MD_FALLTHROUGH();}
             case '*':   md_analyze_emph(ctx, i); break;
             case '~':   md_analyze_tilde(ctx, i); break;
             case '^':   md_analyze_caret(ctx, i); break;
             case '$':   md_analyze_dollar(ctx, i); break;
-            case '.':   MD_FALLTHROUGH();
-            case ':':   MD_FALLTHROUGH();
+            case '.':   {MD_FALLTHROUGH();}
+            case ':':   {MD_FALLTHROUGH();}
             case '@':   md_analyze_permissive_autolink(ctx, i); break;
             case '|':   md_analyze_spoiler(ctx, i); break;
             case '=':   md_analyze_highlight(ctx, i); break;
@@ -6354,7 +6354,7 @@ md_is_html_block_end_condition(MD_CTX* ctx, OFF beg, OFF* p_end)
         case 5:
             return (md_line_contains(ctx, beg, _T("]]>"), 3, p_end) ? 5 : false);
 
-        case 6:     MD_FALLTHROUGH();
+        case 6:     {MD_FALLTHROUGH();}
         case 7:
             if(beg >= ctx->size  ||  ISNEWLINE(beg)) {
                 /* Blank line ends types 6 and 7. */

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -105,9 +105,9 @@
 
 /* For falling through case labels in switch statements. */
 #if defined __clang__ && __clang_major__ >= 12
-    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+    #define MD_FALLTHROUGH()        ;__attribute__((fallthrough))
 #elif defined __GNUC__ && __GNUC__ >= 7
-    #define MD_FALLTHROUGH()        __attribute__((fallthrough))
+    #define MD_FALLTHROUGH()        ;__attribute__((fallthrough))
 #else
     #define MD_FALLTHROUGH()        ((void)0)
 #endif
@@ -4635,17 +4635,17 @@ md_analyze_marks(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
 
         /* Analyze the mark. */
         switch(mark->ch) {
-            case '[':   {MD_FALLTHROUGH();}
-            case '!':   {MD_FALLTHROUGH();}
+            case '[':   MD_FALLTHROUGH();
+            case '!':   MD_FALLTHROUGH();
             case ']':   md_analyze_bracket(ctx, i); break;
             case '&':   md_analyze_entity(ctx, i); break;
-            case '_':   {MD_FALLTHROUGH();}
+            case '_':   MD_FALLTHROUGH();
             case '*':   md_analyze_emph(ctx, i); break;
             case '~':   md_analyze_tilde(ctx, i); break;
             case '^':   md_analyze_caret(ctx, i); break;
             case '$':   md_analyze_dollar(ctx, i); break;
-            case '.':   {MD_FALLTHROUGH();}
-            case ':':   {MD_FALLTHROUGH();}
+            case '.':   MD_FALLTHROUGH();
+            case ':':   MD_FALLTHROUGH();
             case '@':   md_analyze_permissive_autolink(ctx, i); break;
             case '|':   md_analyze_spoiler(ctx, i); break;
             case '=':   md_analyze_highlight(ctx, i); break;
@@ -6354,7 +6354,7 @@ md_is_html_block_end_condition(MD_CTX* ctx, OFF beg, OFF* p_end)
         case 5:
             return (md_line_contains(ctx, beg, _T("]]>"), 3, p_end) ? 5 : false);
 
-        case 6:     {MD_FALLTHROUGH();}
+        case 6:     MD_FALLTHROUGH();
         case 7:
             if(beg >= ctx->size  ||  ISNEWLINE(beg)) {
                 /* Blank line ends types 6 and 7. */


### PR DESCRIPTION
Removes the warning below when -Wpedantic flag is used.

warning: a label can only be part of a statement and a declaration is not a statement [-Wpedantic]