### PR TITLE
Fix for project generation when the project is used as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ if(NOT IDF_TARGET)
     function(CheckPregeneratedFile rel_path)
         execute_process(
             COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-            ${CMAKE_SOURCE_DIR}/${rel_path}
-            ${CMAKE_BINARY_DIR}/${rel_path}.expected
+            ${CMAKE_CURRENT_SOURCE_DIR}/${rel_path}
+            ${CMAKE_CURRENT_BINARY_DIR}/${rel_path}.expected
             RESULT_VARIABLE compare_result
         )
         if(NOT compare_result EQUAL 0)


### PR DESCRIPTION
The f0d5d0e commit introduces a bug when using the project as a submodule: the paths used by CheckPregeneratedFile() are relative to the main project rather than the subproject. This pull request fixes the issue by replacing `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` with `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_CURRENT_BINARY_DIR`.