### PR TITLE
Make md_free_attribute() idempotent and free partial builds

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -1499,10 +1499,21 @@ md_free_attribute(MD_CTX* ctx, MD_ATTRIBUTE_BUILD* build)
 {
     MD_UNUSED(ctx);
 
-    if(build->substr_alloc > 0) {
+    /* A trivial build aliases caller-owned storage and must not be freed.
+     * Every other build owns all three pointers from the moment
+     * md_build_attribute() leaves the trivial branch, even if a growth
+     * realloc later failed while substr_alloc was still 0. Clearing them
+     * keeps this idempotent, which matters because md_build_attribute()
+     * frees on its own abort path before the caller frees again. */
+    if(build->substr_types != build->trivial_types) {
         free(build->text);
         free(build->substr_types);
         free(build->substr_offsets);
+        build->text = NULL;
+        build->substr_types = NULL;
+        build->substr_offsets = NULL;
+        build->substr_alloc = 0;
+        build->substr_count = 0;
     }
 }
 


### PR DESCRIPTION
md_free_attribute() keys its frees on build->substr_alloc. When a growth realloc fails after the arrays have already grown, md_build_attribute() frees the three buffers at its own abort label without resetting it, so the caller frees the same three again at its own abort label; md_enter_leave_span_a(), md_enter_leave_span_wikilink(), md_enter_leave_span_footnote_ref(), md_process_leaf_block() and md_process_footnote_def() all do that. When the first growth realloc fails instead, substr_alloc is still 0, nothing is freed, and the text and type buffers leak. substr_types != trivial_types is the condition that actually separates an owning build from a trivial one.

Found by compiling md4c.c with an allocator that fails the n-th allocation and sweeping n under ASan over a small corpus. This one accounts for 36 of the 40 double frees and all 32 leaks I see there.
