### PR TITLE
Stop double-freeing a committed reference definition's label

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -2501,11 +2501,9 @@ md_is_link_reference_definition(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lin
     return line_index + 1;
 
 abort:
-    /* Failure. */
-    if(def != NULL  &&  def->label_needs_free)
-        free((CHAR*) def->entry.label);
-    if(def != NULL  &&  def->title_needs_free)
-        free(def->title);
+    /* Failure. A non-NULL def is already committed to ctx->ref_def_hashtable,
+     * which owns its label and title and frees them in md_free_ref_defs().
+     * The def == NULL path frees its local label itself, above. */
     return ret;
 }
 


### PR DESCRIPTION
A non-NULL def has already been committed to ctx->ref_def_hashtable by md_add_label_def(), and md_free_ref_defs() frees its label and title during md_parse() cleanup, so the frees at the abort label are a second free. Reaching it needs a definition whose label and title are both multiline, since label_needs_free is only set on the multiline-label branch and the title merge is the allocation that has to fail. The def == NULL path already frees its local label before the goto.

Same fault-injection sweep as #398: this covers the remaining 4 double frees and the one use-after-free.
