### PR TITLE
Remove #define inline

### DIFF
--- a/src/md4c-html.c
+++ b/src/md4c-html.c
@@ -30,17 +30,6 @@
 #include "entity.h"
 
 
-#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199409L
-    /* C89/90 or old compilers in general may not understand "inline". */
-    #if defined __GNUC__
-        #define inline __inline__
-    #elif defined _MSC_VER
-        #define inline __inline
-    #else
-        #define inline
-    #endif
-#endif
-
 #ifdef _WIN32
     #define snprintf _snprintf
 #endif

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -38,17 +38,6 @@
  ***  Miscellaneous Stuff  ***
  *****************************/
 
-#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199409L
-    /* C89/90 or old compilers in general may not understand "inline". */
-    #if defined __GNUC__
-        #define inline __inline__
-    #elif defined _MSC_VER
-        #define inline __inline
-    #else
-        #define inline
-    #endif
-#endif
-
 /* Make the UTF-8 support the default. */
 #if !defined MD4C_USE_ASCII && !defined MD4C_USE_UTF8 && !defined MD4C_USE_UTF16
     #define MD4C_USE_UTF8


### PR DESCRIPTION
If you want to see how many complaints you will get. May cause problems for Qt for INTEGRITY. md4c is optionally used in QTextDocument, which is a class within the Qt GUI module. The Qt GUI module is a supported module for Qt for INTEGRITY.

It looks like the current Green Hills Software compiler version does support the inline keyword, but I'm not really sure.

@ec1oud do you know if this will cause a problem?

Closes: #401