### PR TITLE
Add <video> to block-level HTML tag list (type 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Next Version (Work in Progress)
 
+Changes:
+
+  * Add `<video>` to the list of block-level HTML tags (type 6).
+
 New Features:
 
   * Add blank line preservation, enabled with the flag

--- a/src/md4c.c
+++ b/src/md4c.c
@@ -6187,6 +6187,7 @@ static const TAG s6[] = { X("search"), X("section"), X("summary"), Xend };
 static const TAG t6[] = { X("table"), X("tbody"), X("td"), X("tfoot"), X("th"),
                           X("thead"), X("title"), X("tr"), X("track"), Xend };
 static const TAG u6[] = { X("ul"), Xend };
+static const TAG v6[] = { X("video"), Xend };
 static const TAG xx[] = { Xend };
 
 #undef X
@@ -6202,7 +6203,7 @@ md_is_html_block_start_condition(MD_CTX* ctx, OFF beg)
      * tree to speed-up the search. */
     static const TAG* map6[26] = {
         a6, b6, c6, d6, xx, f6, xx, h6, i6, xx, xx, l6, m6,
-        n6, o6, p6, xx, xx, s6, t6, u6, xx, xx, xx, xx, xx
+        n6, o6, p6, xx, xx, s6, t6, u6, v6, xx, xx, xx, xx
     };
     OFF off = beg + 1;
     int i;

--- a/test/spec-video-tag.txt
+++ b/test/spec-video-tag.txt
@@ -1,0 +1,79 @@
+
+# Video Tag (Block-Level)
+
+The `<video>` element is recognized as a type 6 block-level HTML tag,
+consistent with how other media-related tags like `<iframe>` and `<track>`
+are handled.
+
+
+## Basic recognition
+
+A single-line `<video>` tag is parsed as an HTML block:
+
+```````````````````````````````` example
+<video src="video.mp4"></video>
+
+okay.
+.
+<video src="video.mp4"></video>
+<p>okay.</p>
+````````````````````````````````
+
+A multi-line `<video>` tag:
+
+```````````````````````````````` example
+<video src="video.mp4">
+</video>
+.
+<video src="video.mp4">
+</video>
+````````````````````````````````
+
+
+## Tag with attributes
+
+Attributes on the tag are preserved in the HTML output:
+
+```````````````````````````````` example
+<video src="video.mp4" controls autoplay></video>
+.
+<video src="video.mp4" controls autoplay></video>
+````````````````````````````````
+
+
+## Followed by content on the same line
+
+Unlike type 7 tags, a type 6 tag does not require the rest of the line
+to be blank:
+
+```````````````````````````````` example
+<video src="video.mp4"></video>some trailing text
+.
+<video src="video.mp4"></video>some trailing text
+````````````````````````````````
+
+
+## Inside a blockquote
+
+```````````````````````````````` example
+> <video src="video.mp4"></video>
+.
+<blockquote>
+<video src="video.mp4"></video>
+</blockquote>
+````````````````````````````````
+
+
+## Inside a list item
+
+```````````````````````````````` example
+- <video src="video.mp4"></video>
+- plain item
+.
+<ul>
+<li>
+<video src="video.mp4"></video>
+</li>
+<li>plain item</li>
+</ul>
+````````````````````````````````


### PR DESCRIPTION
## Summary

The `<video>` element is widely used in markdown to embed video content but is not currently recognized as a block-level HTML tag. Without type 6 recognition, `<video>` falls back to type 7, which does not allow any content after the tag on the same line.

Adding `video` to the type 6 tag list allows `<video src="url"></video>` to be parsed as an HTML block regardless of what follows the opening tag on the same line — consistent with how other media-related tags like `<iframe>` and `<track>` are already handled.

## Changes

- **`src/md4c.c`** — Added `v6[]` array with `"video"` and updated `map6[21]` (`'v'` slot) to point to it.
- **`test/spec-video-tag.txt`** — New test file with 6 examples covering basic recognition, attributes, trailing content, blockquote and list contexts.
- **`CHANGELOG.md`** — Added entry under "Next Version".

`test/normalize.py` already includes `video` in `is_block_tag()` — no change needed.

Reported to the CommonMark spec project: [commonmark/commonmark-spec#841](https://github.com/commonmark/commonmark-spec/issues/841).