### PR TITLE
Wiki links: do not mistake a spoiler '||' for the label delimiter

### DIFF
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -3791,7 +3791,7 @@ md_resolve_bracket_wikilink(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
     delim_index = opener_index + 1;
     while(delim_index < closer_index) {
         MD_MARK* m = &ctx->marks[delim_index];
-        if(m->ch == _T('|')) {
+        if(m->ch == _T('|')  &&  m->end - m->beg == 1) {
             delim = m;
             break;
         }

--- a/test/spec-spoilers.txt
+++ b/test/spec-spoilers.txt
@@ -443,3 +443,24 @@ A wiki link whose label contains an unrelated `|` character:
 .
 --fspoilers --fwiki-links
 ````````````````````````````````
+
+A `||` inside a wiki link is a spoiler delimiter, not the label separator, so
+the following single `|` still separates the target from the label:
+
+```````````````````````````````` example
+[[a||b|c]]
+.
+<p><x-wikilink data-target="a||b">c</x-wikilink></p>
+.
+--fspoilers --fwiki-links
+````````````````````````````````
+
+A wiki link containing a `||` and no other `|` has no label:
+
+```````````````````````````````` example
+[[a||b]]
+.
+<p><x-wikilink data-target="a||b">a||b</x-wikilink></p>
+.
+--fspoilers --fwiki-links
+````````````````````````````````


### PR DESCRIPTION
## Problem

`md_resolve_bracket_wikilink` picks the wiki link's target/label separator by looking at the mark character alone (`src/md4c.c:3791-3797`):

```c
    delim_index = opener_index + 1;
    while(delim_index < closer_index) {
        MD_MARK* m = &ctx->marks[delim_index];
        if(m->ch == _T('|')) {
            delim = m;
            break;
        }
```

With `MD_FLAG_SPOILERS` there are two different marks whose `ch` is `'|'`. `src/md4c.c:3534-3540` adds a `||` pair as **one** mark of length 2, and `src/md4c.c:3543-3547` adds a lone `|` as a mark of length 1. The scan above accepts either, so a `||` inside a wiki link is taken as the label separator.

The caller then does (`src/md4c.c:3820-3824`):

```c
    if(delim != NULL) {
        if(delim->end < closer->beg) {
            md_disable_marks(ctx, opener_index+1, delim_index);
            delim->flags |= MD_MARK_RESOLVED;
            opener->end = delim->beg;
```

so the destination is cut at the *first* pipe of the pair, and the spoiler mark is left `MD_MARK_RESOLVED` without `MD_MARK_OPENER`. `md_process_inlines` still recognises it as a spoiler boundary, because it is two characters long (`src/md4c.c:4950-4956`), and takes the `else` branch - emitting a closing spoiler tag that nothing opened.

## Reachability

Built from `00788b15` and run through the shipped `md2html`, i.e. the public `md_parse()` with `MD_FLAG_WIKILINKS | MD_FLAG_SPOILERS` (`md2html/md2html.c:412,417`):

```
$ md2html --fwiki-links --fspoilers

[[a||b|c]]   before: <p><x-wikilink data-target="a"></x-spoiler>b|c</x-wikilink></p>
             after:  <p><x-wikilink data-target="a||b">c</x-wikilink></p>

[[a||b]]     before: <p><x-wikilink data-target="a"></x-spoiler>b</x-wikilink></p>
             after:  <p><x-wikilink data-target="a||b">a||b</x-wikilink></p>

[[a|||b]]    before: <p><x-wikilink data-target="a"></x-spoiler>|b</x-wikilink></p>
             after:  <p><x-wikilink data-target="a||">b</x-wikilink></p>
```

The `</x-spoiler>` is unbalanced: no spoiler span was ever entered, so a consumer that pairs tags sees a stray close.

## Why this is a bug and not a design choice

Every other consumer of a `'|'` mark already disambiguates by length. Your own `md_process_inlines` at `src/md4c.c:4951` already does this - `if(mark->end - mark->beg == 2)` before it will treat a `'|'` mark as a spoiler boundary at all. The full set:

| site | test on a `'|'` mark |
| --- | --- |
| `src/md4c.c:4951` - spoiler span emission | `end - beg == 2` |
| `src/md4c.c:4702` - table cell boundary selection | `end - beg == 1` |
| `src/md4c.c:4329` - `md_analyze_spoiler` | `end - beg != 2` -> return |
| `src/md4c.c:3779-3781` - this same function, on its own `[`, `[`, `]` marks | `end - beg != 1` -> return false |
| `src/md4c.c:3794` - this scan | **`ch` only** |

The mark builder states the intent directly (`src/md4c.c:3531-3533`):

> ```
> /* A potential spoiler delimiter: || ... ||
>  * Checked before the single-| handler so a double pipe is consumed
>  * as one mark and does not become two cell boundaries. */
> ```

and `test/spec-spoilers.txt:427` already says "Wiki links with a `|` separator must not be mistaken for spoiler delimiters". The existing examples there only cover a wiki link that contains no `||`, so the case where the two features actually collide was never exercised.

## Fix

```diff
--- a/src/md4c.c
+++ b/src/md4c.c
@@ -3791,7 +3791,7 @@ md_resolve_bracket_wikilink(MD_CTX* ctx, const MD_LINE* lines, MD_SIZE n_lines,
     delim_index = opener_index + 1;
     while(delim_index < closer_index) {
         MD_MARK* m = &ctx->marks[delim_index];
-        if(m->ch == _T('|')) {
+        if(m->ch == _T('|')  &&  m->end - m->beg == 1) {
             delim = m;
             break;
         }
```

One comparison of two `OFF` fields; no new declaration, so the MSVC rows and `-Wdeclaration-after-statement` are unaffected.

## Test

Two examples appended to `test/spec-spoilers.txt`, in the section that already states the invariant:

```
[[a||b|c]]  ->  <p><x-wikilink data-target="a||b">c</x-wikilink></p>
[[a||b]]    ->  <p><x-wikilink data-target="a||b">a||b</x-wikilink></p>
```

Red-green and both mutation directions, `python3 scripts/run-tests.py` each time:

| `src/md4c.c:3794` predicate | spec-spoilers.txt | spec-wiki-links.txt | regressions.txt |
| --- | --- | --- | --- |
| `m->ch == _T('|')` (as shipped) | 35 passed, **2 failed** (ex. 36, 37) | 23 / 0 | 82 / 0 |
| `... && m->end - m->beg == 1` (this PR) | **37 passed, 0 failed** | 23 / 0 | 82 / 0 |
| `... && m->end - m->beg <= 2` (over-permissive) | 35 passed, **2 failed** (ex. 36, 37) | 23 / 0 | 82 / 0 |
| `... && m->end - m->beg == 2` (over-restrictive) | 32 passed, **5 failed** | 12 passed, **11 failed** | 80 passed, **2 failed** |

The two failing sets are disjoint in the way they should be: relaxing the guard fails exactly the two new examples and nothing else, while tightening it past the single pipe fails 18 examples, 16 of them pre-existing - including the two `regressions.txt` cases added by #348.

`<= 1` and `!= 2` are equivalent mutants here rather than a gap in the tests: a mark always spans at least one character, and `src/md4c.c:3536` and `:3544` are the only two places that create a `'|'` mark, at length 2 and length 1 respectively. I kept `== 1` so the predicate says what it means without depending on that.

## Verification

Both Linux CI rows replicated locally with the workflow's `CFLAGS='--coverage -Werror'` plus the project's own `-Wall -Wextra -Wshadow -Wdeclaration-after-statement` (`CMakeLists.txt:96,101`):

- Debug (`-g -O0`): 0 warnings, `scripts/run-tests.py` 1017 passed / 0 failed
- Release (`-O3 -DNDEBUG`): 0 warnings, 1017 passed / 0 failed
- pathological inputs: 29 passed / 0 failed
- ASAN + UBSAN build run over every `test/*.txt` with all extension flags, plus the wiki-link/spoiler edge inputs above: 0 diagnostics

## Worth flagging

`[[||]]` changes from `<p>[[||]]</p>` (not a wiki link) to `<p><x-wikilink data-target="||">||</x-wikilink></p>`. Before the fix the `||` was chosen as the delimiter and, sitting immediately before the closer, took the `[[foo|]]` branch at `src/md4c.c:3826-3828`, which empties the destination and rejects the link. With the fix there is no length-1 pipe, so it is a wiki link with no label - the same shape as the new `[[a||b]]` example. `[[|]]`, `[[|b]]` and `[[a|]]` are unchanged.

---

Disclosure: this patch was prepared with AI assistance. I ran the build, the test suite, the red-green and both mutation directions, and the sanitizer sweep myself, and the numbers above are from those runs.
